### PR TITLE
feat: add bare-metal TPM 2.0 attestation platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tss-esapi",
  "x509-cert",
  "x509-parser",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # library can verify evidence from any supported TEE without extra feature flags.
 # Embedders building minimal binaries should use `default-features = false` and
 # enable only the platforms they need.
-default = ["snp", "tdx", "az-snp", "az-tdx", "gcp-snp", "gcp-tdx"]
+default = ["snp", "tdx", "az-snp", "az-tdx", "gcp-snp", "gcp-tdx", "tpm"]
 
 # Platform features — gate which TEE platforms are compiled in
 snp = ["dep:sev", "dep:x509-parser"]
@@ -20,12 +20,13 @@ az-tdx = ["tdx"]       # Azure TDX depends on bare-metal TDX for quote parsing
 gcp-snp = ["snp"]      # GCP SNP depends on bare-metal SNP for report parsing
 gcp-tdx = ["tdx"]      # GCP TDX depends on bare-metal TDX for quote parsing
 dstack = ["tdx"]       # dstack proxies TDX quotes via Unix socket
+tpm = []               # Bare-metal TPM 2.0 attestation (no TEE required)
 
 # Guest-side evidence generation (Linux-only, requires TEE hardware).
 # Combine with platform features for per-platform builds:
 #   attest + snp           → bare-metal SNP attestation only
 #   attest + az-snp-attest → Azure SNP attestation (pulls az-snp-vtpm)
-#   attest (+ defaults)    → bare-metal + GCP attesters only.
+#   attest (+ defaults)    → bare-metal + GCP + TPM attesters only.
 #
 # Azure vTPM attesters are opt-in (not folded into `attest`) because
 # az-snp-vtpm / az-tdx-vtpm 0.8.x pull az-cvm-vtpm *with default features*
@@ -41,7 +42,7 @@ dstack = ["tdx"]       # dstack proxies TDX quotes via Unix socket
 # `default-features = false` on its az-cvm-vtpm dep in az-snp-vtpm and
 # az-tdx-vtpm. Until then, the opt-in split keeps the generic `attest`
 # build free of the sev/openssl pull.
-attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:zerocopy"]
+attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:zerocopy", "dep:tss-esapi"]
 az-snp-attest = ["attest", "az-snp", "dep:az-snp-vtpm"]
 az-tdx-attest = ["attest", "az-tdx", "dep:az-tdx-vtpm"]
 
@@ -100,6 +101,7 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "time", "net", "io-
 [target.'cfg(target_os = "linux")'.dependencies]
 az-snp-vtpm = { version = "0.8.1", default-features = false, features = ["attester"], optional = true }
 az-tdx-vtpm = { version = "0.8", default-features = false, features = ["attester"], optional = true }
+tss-esapi = { version = "7", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -90,6 +90,7 @@ enum PlatformArg {
     AzTdx,
     GcpSnp,
     GcpTdx,
+    Tpm,
 }
 
 #[cfg(all(feature = "attest", target_os = "linux"))]
@@ -102,6 +103,7 @@ impl PlatformArg {
             PlatformArg::AzTdx => attestation::PlatformType::AzTdx,
             PlatformArg::GcpSnp => attestation::PlatformType::GcpSnp,
             PlatformArg::GcpTdx => attestation::PlatformType::GcpTdx,
+            PlatformArg::Tpm => attestation::PlatformType::Tpm,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,11 @@ pub fn detect() -> Result<PlatformType> {
         return Ok(PlatformType::Snp);
     }
 
+    #[cfg(feature = "tpm")]
+    if platforms::tpm::attest::is_available() {
+        return Ok(PlatformType::Tpm);
+    }
+
     Err(AttestationError::NoPlatformDetected)
 }
 
@@ -182,6 +187,12 @@ pub async fn attest(
         #[cfg(feature = "dstack")]
         PlatformType::Dstack => {
             let evidence = platforms::dstack::attest::generate_evidence(report_data).await?;
+            serde_json::to_value(&evidence)
+                .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?
+        }
+        #[cfg(feature = "tpm")]
+        PlatformType::Tpm => {
+            let evidence = platforms::tpm::attest::generate_evidence(report_data).await?;
             serde_json::to_value(&evidence)
                 .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?
         }
@@ -345,6 +356,13 @@ impl Verifier {
                     Some(self.tdx_provider.as_ref()),
                 )
                 .await
+            }
+            #[cfg(feature = "tpm")]
+            PlatformType::Tpm => {
+                let evidence: platforms::tpm::evidence::TpmEvidence =
+                    serde_json::from_value(envelope.evidence)
+                        .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?;
+                platforms::tpm::verify::verify_evidence(&evidence, params).await
             }
             #[cfg(feature = "dstack")]
             PlatformType::Dstack => {

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -12,5 +12,7 @@ pub mod gcp_tdx;
 pub mod snp;
 #[cfg(feature = "tdx")]
 pub mod tdx;
-#[cfg(any(feature = "az-snp", feature = "az-tdx"))]
+#[cfg(feature = "tpm")]
+pub mod tpm;
+#[cfg(any(feature = "az-snp", feature = "az-tdx", feature = "tpm"))]
 pub mod tpm_common;

--- a/src/platforms/tpm/attest.rs
+++ b/src/platforms/tpm/attest.rs
@@ -1,0 +1,241 @@
+use std::str::FromStr;
+
+use crate::error::{AttestationError, Result};
+use crate::platforms::tpm_common::TpmQuote;
+
+use super::evidence::TpmEvidence;
+
+const TPM_DEVICE_PATH: &str = "/dev/tpmrm0";
+const TPM_SYSFS_PATH: &str = "/sys/class/tpm/tpm0";
+const MAX_REPORT_DATA: usize = 64;
+
+/// RSA EK certificate NV index (TCG standard).
+const EK_CERT_NV_INDEX: u32 = 0x01C0_0002;
+
+pub fn is_available() -> bool {
+    std::path::Path::new(TPM_DEVICE_PATH).exists() || std::path::Path::new(TPM_SYSFS_PATH).exists()
+}
+
+/// Generate TPM attestation evidence.
+///
+/// Creates a transient Attestation Key (AK) under the Storage Root Key,
+/// generates a TPM2_Quote with the provided report_data as qualifyingData,
+/// and reads PCR values for SHA-256 banks 0-23.
+pub async fn generate_evidence(report_data: &[u8]) -> Result<TpmEvidence> {
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        interface_types::{
+            algorithm::{HashingAlgorithm, PublicAlgorithm, RsaSchemeAlgorithm},
+            key_bits::RsaKeyBits,
+            resource_handles::Hierarchy,
+        },
+        structures::{
+            Data, PcrSelectionListBuilder, PcrSlot, PublicBuilder, PublicKeyRsa,
+            PublicRsaParametersBuilder, RsaExponent, RsaScheme, SignatureScheme,
+            SymmetricDefinition, SymmetricDefinitionObject,
+        },
+        tcti_ldr::{DeviceConfig, TctiNameConf},
+        traits::Marshall,
+        Context,
+    };
+
+    if report_data.len() > MAX_REPORT_DATA {
+        return Err(AttestationError::ReportDataTooLarge {
+            max: MAX_REPORT_DATA,
+        });
+    }
+
+    let tcti =
+        TctiNameConf::Device(DeviceConfig::from_str(TPM_DEVICE_PATH).map_err(|e| {
+            AttestationError::HardwareAccessFailed(format!("TPM device config: {e}"))
+        })?);
+
+    let mut context = Context::new(tcti).map_err(|e| {
+        AttestationError::HardwareAccessFailed(format!("TPM context creation failed: {e}"))
+    })?;
+
+    let session = context
+        .start_auth_session(
+            None,
+            None,
+            None,
+            tss_esapi::constants::SessionType::Hmac,
+            SymmetricDefinition::AES_128_CFB,
+            HashingAlgorithm::Sha256,
+        )
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("auth session: {e}")))?
+        .ok_or_else(|| {
+            AttestationError::HardwareAccessFailed("failed to create auth session".into())
+        })?;
+
+    context.set_sessions((Some(session), None, None));
+
+    // SRK: RSA 2048, restricted, decrypt
+    let srk_public = PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Rsa)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+        .with_object_attributes(
+            ObjectAttributesBuilder::new()
+                .with_fixed_tpm(true)
+                .with_fixed_parent(true)
+                .with_sensitive_data_origin(true)
+                .with_user_with_auth(true)
+                .with_restricted(true)
+                .with_decrypt(true)
+                .build()
+                .map_err(|e| {
+                    AttestationError::HardwareAccessFailed(format!("SRK attributes: {e}"))
+                })?,
+        )
+        .with_rsa_parameters(
+            PublicRsaParametersBuilder::new()
+                .with_scheme(RsaScheme::Null)
+                .with_key_bits(RsaKeyBits::Rsa2048)
+                .with_exponent(RsaExponent::default())
+                .with_symmetric(SymmetricDefinitionObject::AES_128_CFB)
+                .build()
+                .map_err(|e| {
+                    AttestationError::HardwareAccessFailed(format!("SRK RSA params: {e}"))
+                })?,
+        )
+        .with_rsa_unique_identifier(PublicKeyRsa::default())
+        .build()
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("SRK public: {e}")))?;
+
+    let srk_result = context
+        .create_primary(Hierarchy::Owner, srk_public, None, None, None, None)
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("create SRK: {e}")))?;
+
+    let srk_handle = srk_result.key_handle;
+
+    // AK: RSA 2048, restricted, sign, RSASSA SHA-256
+    let ak_public = PublicBuilder::new()
+        .with_public_algorithm(PublicAlgorithm::Rsa)
+        .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+        .with_object_attributes(
+            ObjectAttributesBuilder::new()
+                .with_fixed_tpm(true)
+                .with_fixed_parent(true)
+                .with_sensitive_data_origin(true)
+                .with_user_with_auth(true)
+                .with_restricted(true)
+                .with_sign_encrypt(true)
+                .build()
+                .map_err(|e| {
+                    AttestationError::HardwareAccessFailed(format!("AK attributes: {e}"))
+                })?,
+        )
+        .with_rsa_parameters(
+            PublicRsaParametersBuilder::new()
+                .with_scheme(
+                    RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
+                        .map_err(|e| {
+                        AttestationError::HardwareAccessFailed(format!("AK scheme: {e}"))
+                    })?,
+                )
+                .with_key_bits(RsaKeyBits::Rsa2048)
+                .with_exponent(RsaExponent::default())
+                .with_symmetric(SymmetricDefinitionObject::Null)
+                .build()
+                .map_err(|e| {
+                    AttestationError::HardwareAccessFailed(format!("AK RSA params: {e}"))
+                })?,
+        )
+        .with_rsa_unique_identifier(PublicKeyRsa::default())
+        .build()
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("AK public: {e}")))?;
+
+    let ak_result = context
+        .create(srk_handle, ak_public, None, None, None, None)
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("create AK: {e}")))?;
+
+    let ak_handle = context
+        .load(
+            srk_handle,
+            ak_result.out_private,
+            ak_result.out_public.clone(),
+        )
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("load AK: {e}")))?;
+
+    let pcr_slots: Vec<PcrSlot> = (0..24u32).map(|i| PcrSlot::try_from(i).unwrap()).collect();
+
+    let pcr_selection = PcrSelectionListBuilder::new()
+        .with_selection(HashingAlgorithm::Sha256, &pcr_slots)
+        .build()
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("PCR selection: {e}")))?;
+
+    let qualifying_data = Data::try_from(report_data)
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("qualifying data: {e}")))?;
+
+    let (attest, signature) = context
+        .quote(
+            ak_handle.into(),
+            qualifying_data,
+            SignatureScheme::Null,
+            pcr_selection.clone(),
+        )
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("TPM2_Quote: {e}")))?;
+
+    // pcr_read returns (update_counter, pcr_selection_out, digest_list)
+    let (_, _, pcr_digests) = context
+        .pcr_read(pcr_selection)
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("PCR read: {e}")))?;
+
+    let ak_pub_bytes = ak_result
+        .out_public
+        .marshall()
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("marshal AK public: {e}")))?;
+
+    let ek_cert = read_ek_cert(&mut context);
+
+    let _ = context.flush_context(ak_handle.into());
+    let _ = context.flush_context(srk_handle.into());
+
+    let sig_bytes = signature
+        .marshall()
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("marshal signature: {e}")))?;
+    let attest_bytes = attest
+        .marshall()
+        .map_err(|e| AttestationError::HardwareAccessFailed(format!("marshal attest: {e}")))?;
+
+    // DigestList.value() returns &[Digest], each Digest derefs to &[u8]
+    let pcr_values: Vec<String> = pcr_digests
+        .value()
+        .iter()
+        .map(|digest| hex::encode(digest.value()))
+        .collect();
+
+    let mut pcrs = pcr_values;
+    pcrs.resize(24, "00".repeat(32));
+
+    Ok(TpmEvidence {
+        version: 1,
+        tpm_quote: TpmQuote {
+            signature: hex::encode(&sig_bytes),
+            message: hex::encode(&attest_bytes),
+            pcrs,
+        },
+        ak_pub: hex::encode(&ak_pub_bytes),
+        ek_cert,
+    })
+}
+
+/// Returns None if the NV index doesn't exist or can't be read.
+fn read_ek_cert(context: &mut tss_esapi::Context) -> Option<String> {
+    use tss_esapi::handles::NvIndexTpmHandle;
+    use tss_esapi::interface_types::resource_handles::NvAuth;
+
+    let nv_tpm_handle = NvIndexTpmHandle::new(EK_CERT_NV_INDEX).ok()?;
+
+    // Convert TPM handle to ESYS handle via the resource manager
+    let nv_handle = context
+        .execute_without_session(|ctx| ctx.tr_from_tpm_public(nv_tpm_handle.into()))
+        .ok()?
+        .into();
+
+    let (nv_public, _) = context.nv_read_public(nv_handle).ok()?;
+    let size = nv_public.data_size() as u16;
+    let data = context.nv_read(NvAuth::Owner, nv_handle, size, 0).ok()?;
+
+    Some(hex::encode(data.value()))
+}

--- a/src/platforms/tpm/attest.rs
+++ b/src/platforms/tpm/attest.rs
@@ -1,4 +1,23 @@
-use std::str::FromStr;
+use std::{fmt::Display, path::Path, str::FromStr};
+
+use tss_esapi::{
+    attributes::ObjectAttributesBuilder,
+    constants::SessionType,
+    handles::{KeyHandle, NvIndexTpmHandle},
+    interface_types::{
+        algorithm::{HashingAlgorithm, PublicAlgorithm, RsaSchemeAlgorithm},
+        key_bits::RsaKeyBits,
+        resource_handles::{Hierarchy, NvAuth},
+    },
+    structures::{
+        Attest, Data, DigestList, PcrSelectionList, PcrSelectionListBuilder, PcrSlot, Public,
+        PublicBuilder, PublicKeyRsa, PublicRsaParametersBuilder, RsaExponent, RsaScheme, Signature,
+        SignatureScheme, SymmetricDefinition, SymmetricDefinitionObject,
+    },
+    tcti_ldr::{DeviceConfig, TctiNameConf},
+    traits::Marshall,
+    Context,
+};
 
 use crate::error::{AttestationError, Result};
 use crate::platforms::tpm_common::TpmQuote;
@@ -13,7 +32,18 @@ const MAX_REPORT_DATA: usize = 64;
 const EK_CERT_NV_INDEX: u32 = 0x01C0_0002;
 
 pub fn is_available() -> bool {
-    std::path::Path::new(TPM_DEVICE_PATH).exists() || std::path::Path::new(TPM_SYSFS_PATH).exists()
+    Path::new(TPM_DEVICE_PATH).exists() || Path::new(TPM_SYSFS_PATH).exists()
+}
+
+struct LoadedAk {
+    handle: KeyHandle,
+    public: Vec<u8>,
+}
+
+struct QuoteOutput {
+    attest: Attest,
+    signature: Signature,
+    pcr_digests: DigestList,
 }
 
 /// Generate TPM attestation evidence.
@@ -22,56 +52,72 @@ pub fn is_available() -> bool {
 /// generates a TPM2_Quote with the provided report_data as qualifyingData,
 /// and reads PCR values for SHA-256 banks 0-23.
 pub async fn generate_evidence(report_data: &[u8]) -> Result<TpmEvidence> {
-    use tss_esapi::{
-        attributes::ObjectAttributesBuilder,
-        interface_types::{
-            algorithm::{HashingAlgorithm, PublicAlgorithm, RsaSchemeAlgorithm},
-            key_bits::RsaKeyBits,
-            resource_handles::Hierarchy,
-        },
-        structures::{
-            Data, PcrSelectionListBuilder, PcrSlot, PublicBuilder, PublicKeyRsa,
-            PublicRsaParametersBuilder, RsaExponent, RsaScheme, SignatureScheme,
-            SymmetricDefinition, SymmetricDefinitionObject,
-        },
-        tcti_ldr::{DeviceConfig, TctiNameConf},
-        traits::Marshall,
-        Context,
-    };
+    validate_report_data(report_data)?;
 
+    let mut context = create_context()?;
+    start_hmac_session(&mut context)?;
+
+    let srk_handle = create_srk(&mut context)?;
+    let ak = create_and_load_ak(&mut context, srk_handle)?;
+    let pcr_selection = sha256_pcr_selection()?;
+    let quote = quote_pcrs(&mut context, ak.handle, report_data, pcr_selection)?;
+    let ek_cert = read_ek_cert(&mut context);
+
+    flush_loaded_keys(&mut context, ak.handle, srk_handle);
+
+    build_evidence(ak.public, quote, ek_cert)
+}
+
+fn validate_report_data(report_data: &[u8]) -> Result<()> {
     if report_data.len() > MAX_REPORT_DATA {
         return Err(AttestationError::ReportDataTooLarge {
             max: MAX_REPORT_DATA,
         });
     }
 
-    let tcti =
-        TctiNameConf::Device(DeviceConfig::from_str(TPM_DEVICE_PATH).map_err(|e| {
-            AttestationError::HardwareAccessFailed(format!("TPM device config: {e}"))
-        })?);
+    Ok(())
+}
 
-    let mut context = Context::new(tcti).map_err(|e| {
-        AttestationError::HardwareAccessFailed(format!("TPM context creation failed: {e}"))
-    })?;
+fn create_context() -> Result<Context> {
+    let tcti = TctiNameConf::Device(
+        DeviceConfig::from_str(TPM_DEVICE_PATH)
+            .map_err(|e| hardware_error("TPM device config", e))?,
+    );
 
+    Context::new(tcti).map_err(|e| hardware_error("TPM context creation failed", e))
+}
+
+fn start_hmac_session(context: &mut Context) -> Result<()> {
     let session = context
         .start_auth_session(
             None,
             None,
             None,
-            tss_esapi::constants::SessionType::Hmac,
+            SessionType::Hmac,
             SymmetricDefinition::AES_128_CFB,
             HashingAlgorithm::Sha256,
         )
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("auth session: {e}")))?
+        .map_err(|e| hardware_error("auth session", e))?
         .ok_or_else(|| {
             AttestationError::HardwareAccessFailed("failed to create auth session".into())
         })?;
 
     context.set_sessions((Some(session), None, None));
 
-    // SRK: RSA 2048, restricted, decrypt
-    let srk_public = PublicBuilder::new()
+    Ok(())
+}
+
+fn create_srk(context: &mut Context) -> Result<KeyHandle> {
+    let srk_public = build_srk_public()?;
+    let srk_result = context
+        .create_primary(Hierarchy::Owner, srk_public, None, None, None, None)
+        .map_err(|e| hardware_error("create SRK", e))?;
+
+    Ok(srk_result.key_handle)
+}
+
+fn build_srk_public() -> Result<Public> {
+    PublicBuilder::new()
         .with_public_algorithm(PublicAlgorithm::Rsa)
         .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(
@@ -83,9 +129,7 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<TpmEvidence> {
                 .with_restricted(true)
                 .with_decrypt(true)
                 .build()
-                .map_err(|e| {
-                    AttestationError::HardwareAccessFailed(format!("SRK attributes: {e}"))
-                })?,
+                .map_err(|e| hardware_error("SRK attributes", e))?,
         )
         .with_rsa_parameters(
             PublicRsaParametersBuilder::new()
@@ -94,22 +138,33 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<TpmEvidence> {
                 .with_exponent(RsaExponent::default())
                 .with_symmetric(SymmetricDefinitionObject::AES_128_CFB)
                 .build()
-                .map_err(|e| {
-                    AttestationError::HardwareAccessFailed(format!("SRK RSA params: {e}"))
-                })?,
+                .map_err(|e| hardware_error("SRK RSA params", e))?,
         )
         .with_rsa_unique_identifier(PublicKeyRsa::default())
         .build()
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("SRK public: {e}")))?;
+        .map_err(|e| hardware_error("SRK public", e))
+}
 
-    let srk_result = context
-        .create_primary(Hierarchy::Owner, srk_public, None, None, None, None)
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("create SRK: {e}")))?;
+fn create_and_load_ak(context: &mut Context, srk_handle: KeyHandle) -> Result<LoadedAk> {
+    let ak_public = build_ak_public()?;
+    let ak_result = context
+        .create(srk_handle, ak_public, None, None, None, None)
+        .map_err(|e| hardware_error("create AK", e))?;
 
-    let srk_handle = srk_result.key_handle;
+    let public = ak_result
+        .out_public
+        .marshall()
+        .map_err(|e| hardware_error("marshal AK public", e))?;
 
-    // AK: RSA 2048, restricted, sign, RSASSA SHA-256
-    let ak_public = PublicBuilder::new()
+    let handle = context
+        .load(srk_handle, ak_result.out_private, ak_result.out_public)
+        .map_err(|e| hardware_error("load AK", e))?;
+
+    Ok(LoadedAk { handle, public })
+}
+
+fn build_ak_public() -> Result<Public> {
+    PublicBuilder::new()
         .with_public_algorithm(PublicAlgorithm::Rsa)
         .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
         .with_object_attributes(
@@ -121,110 +176,110 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<TpmEvidence> {
                 .with_restricted(true)
                 .with_sign_encrypt(true)
                 .build()
-                .map_err(|e| {
-                    AttestationError::HardwareAccessFailed(format!("AK attributes: {e}"))
-                })?,
+                .map_err(|e| hardware_error("AK attributes", e))?,
         )
         .with_rsa_parameters(
             PublicRsaParametersBuilder::new()
                 .with_scheme(
                     RsaScheme::create(RsaSchemeAlgorithm::RsaSsa, Some(HashingAlgorithm::Sha256))
-                        .map_err(|e| {
-                        AttestationError::HardwareAccessFailed(format!("AK scheme: {e}"))
-                    })?,
+                        .map_err(|e| hardware_error("AK scheme", e))?,
                 )
                 .with_key_bits(RsaKeyBits::Rsa2048)
                 .with_exponent(RsaExponent::default())
                 .with_symmetric(SymmetricDefinitionObject::Null)
                 .build()
-                .map_err(|e| {
-                    AttestationError::HardwareAccessFailed(format!("AK RSA params: {e}"))
-                })?,
+                .map_err(|e| hardware_error("AK RSA params", e))?,
         )
         .with_rsa_unique_identifier(PublicKeyRsa::default())
         .build()
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("AK public: {e}")))?;
+        .map_err(|e| hardware_error("AK public", e))
+}
 
-    let ak_result = context
-        .create(srk_handle, ak_public, None, None, None, None)
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("create AK: {e}")))?;
+fn sha256_pcr_selection() -> Result<PcrSelectionList> {
+    let pcr_slots: Vec<PcrSlot> = (0..24u32)
+        .map(PcrSlot::try_from)
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| hardware_error("PCR slot", e))?;
 
-    let ak_handle = context
-        .load(
-            srk_handle,
-            ak_result.out_private,
-            ak_result.out_public.clone(),
-        )
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("load AK: {e}")))?;
-
-    let pcr_slots: Vec<PcrSlot> = (0..24u32).map(|i| PcrSlot::try_from(i).unwrap()).collect();
-
-    let pcr_selection = PcrSelectionListBuilder::new()
+    PcrSelectionListBuilder::new()
         .with_selection(HashingAlgorithm::Sha256, &pcr_slots)
         .build()
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("PCR selection: {e}")))?;
+        .map_err(|e| hardware_error("PCR selection", e))
+}
 
-    let qualifying_data = Data::try_from(report_data)
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("qualifying data: {e}")))?;
+fn quote_pcrs(
+    context: &mut Context,
+    ak_handle: KeyHandle,
+    report_data: &[u8],
+    pcr_selection: PcrSelectionList,
+) -> Result<QuoteOutput> {
+    let qualifying_data =
+        Data::try_from(report_data).map_err(|e| hardware_error("qualifying data", e))?;
 
     let (attest, signature) = context
         .quote(
-            ak_handle.into(),
+            ak_handle,
             qualifying_data,
             SignatureScheme::Null,
             pcr_selection.clone(),
         )
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("TPM2_Quote: {e}")))?;
+        .map_err(|e| hardware_error("TPM2_Quote", e))?;
 
-    // pcr_read returns (update_counter, pcr_selection_out, digest_list)
     let (_, _, pcr_digests) = context
         .pcr_read(pcr_selection)
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("PCR read: {e}")))?;
+        .map_err(|e| hardware_error("PCR read", e))?;
 
-    let ak_pub_bytes = ak_result
-        .out_public
-        .marshall()
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("marshal AK public: {e}")))?;
+    Ok(QuoteOutput {
+        attest,
+        signature,
+        pcr_digests,
+    })
+}
 
-    let ek_cert = read_ek_cert(&mut context);
-
+fn flush_loaded_keys(context: &mut Context, ak_handle: KeyHandle, srk_handle: KeyHandle) {
     let _ = context.flush_context(ak_handle.into());
     let _ = context.flush_context(srk_handle.into());
+}
 
-    let sig_bytes = signature
+fn build_evidence(
+    ak_pub_bytes: Vec<u8>,
+    quote: QuoteOutput,
+    ek_cert: Option<String>,
+) -> Result<TpmEvidence> {
+    let sig_bytes = quote
+        .signature
         .marshall()
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("marshal signature: {e}")))?;
-    let attest_bytes = attest
+        .map_err(|e| hardware_error("marshal signature", e))?;
+    let attest_bytes = quote
+        .attest
         .marshall()
-        .map_err(|e| AttestationError::HardwareAccessFailed(format!("marshal attest: {e}")))?;
-
-    // DigestList.value() returns &[Digest], each Digest derefs to &[u8]
-    let pcr_values: Vec<String> = pcr_digests
-        .value()
-        .iter()
-        .map(|digest| hex::encode(digest.value()))
-        .collect();
-
-    let mut pcrs = pcr_values;
-    pcrs.resize(24, "00".repeat(32));
+        .map_err(|e| hardware_error("marshal attest", e))?;
 
     Ok(TpmEvidence {
         version: 1,
         tpm_quote: TpmQuote {
             signature: hex::encode(&sig_bytes),
             message: hex::encode(&attest_bytes),
-            pcrs,
+            pcrs: encode_pcrs(&quote.pcr_digests),
         },
         ak_pub: hex::encode(&ak_pub_bytes),
         ek_cert,
     })
 }
 
-/// Returns None if the NV index doesn't exist or can't be read.
-fn read_ek_cert(context: &mut tss_esapi::Context) -> Option<String> {
-    use tss_esapi::handles::NvIndexTpmHandle;
-    use tss_esapi::interface_types::resource_handles::NvAuth;
+fn encode_pcrs(pcr_digests: &DigestList) -> Vec<String> {
+    let mut pcrs: Vec<String> = pcr_digests
+        .value()
+        .iter()
+        .map(|digest| hex::encode(digest.value()))
+        .collect();
 
+    pcrs.resize(24, "00".repeat(32));
+    pcrs
+}
+
+/// Returns None if the NV index doesn't exist or can't be read.
+fn read_ek_cert(context: &mut Context) -> Option<String> {
     let nv_tpm_handle = NvIndexTpmHandle::new(EK_CERT_NV_INDEX).ok()?;
 
     // Convert TPM handle to ESYS handle via the resource manager
@@ -238,4 +293,8 @@ fn read_ek_cert(context: &mut tss_esapi::Context) -> Option<String> {
     let data = context.nv_read(NvAuth::Owner, nv_handle, size, 0).ok()?;
 
     Some(hex::encode(data.value()))
+}
+
+fn hardware_error(operation: &str, error: impl Display) -> AttestationError {
+    AttestationError::HardwareAccessFailed(format!("{operation}: {error}"))
 }

--- a/src/platforms/tpm/evidence.rs
+++ b/src/platforms/tpm/evidence.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+use crate::platforms::tpm_common::TpmQuote;
+
+/// Bare-metal TPM 2.0 attestation evidence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TpmEvidence {
+    /// Evidence format version (currently 1).
+    pub version: u32,
+    /// TPM attestation quote (signature, TPMS_ATTEST message, PCR values).
+    pub tpm_quote: TpmQuote,
+    /// AK public key as a TPM2B_PUBLIC structure, hex-encoded.
+    pub ak_pub: String,
+    /// EK certificate (DER), hex-encoded. Provides platform identity
+    /// if the TPM manufacturer provisioned one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ek_cert: Option<String>,
+}

--- a/src/platforms/tpm/mod.rs
+++ b/src/platforms/tpm/mod.rs
@@ -1,0 +1,5 @@
+pub mod evidence;
+pub mod verify;
+
+#[cfg(all(feature = "attest", target_os = "linux"))]
+pub mod attest;

--- a/src/platforms/tpm/verify.rs
+++ b/src/platforms/tpm/verify.rs
@@ -1,0 +1,58 @@
+use crate::error::{AttestationError, Result};
+use crate::platforms::tpm_common;
+use crate::types::{Claims, PlatformType, TcbInfo, VerifyParams};
+
+use super::evidence::TpmEvidence;
+
+/// Verify bare-metal TPM attestation evidence.
+///
+/// Trust model: the caller trusts the AK public key included in the evidence.
+/// For stronger platform identity, verify the optional EK certificate chain
+/// against TPM manufacturer roots.
+pub async fn verify_evidence(
+    evidence: &TpmEvidence,
+    params: &VerifyParams,
+) -> Result<crate::types::VerificationResult> {
+    if evidence.version != 1 {
+        return Err(AttestationError::EvidenceDeserialize(format!(
+            "unsupported TPM evidence version: {}",
+            evidence.version
+        )));
+    }
+
+    let (tpm_sig, tpm_msg, tpm_pcrs) = tpm_common::decode_tpm_quote(&evidence.tpm_quote)?;
+
+    let ak_pub_bytes = hex::decode(&evidence.ak_pub)
+        .map_err(|e| AttestationError::EvidenceDeserialize(format!("invalid ak_pub hex: {e}")))?;
+
+    // verify_tpm_signature falls back to TPM2B_PUBLIC parsing when JWK fails,
+    // which is always the case for raw TPM2B_PUBLIC bytes.
+    tpm_common::verify_tpm_signature(&tpm_sig, &tpm_msg, &ak_pub_bytes)?;
+    tpm_common::verify_tpm_pcrs(&tpm_msg, &tpm_pcrs)?;
+
+    let report_data_match =
+        tpm_common::check_report_data(&tpm_msg, params.expected_report_data.as_deref())?;
+
+    let firmware_version = tpm_common::extract_firmware_version(&tpm_msg).unwrap_or(0);
+    let nonce = tpm_common::extract_tpm_nonce(&tpm_msg).unwrap_or_default();
+
+    let signed_data = nonce.clone();
+    let base_claims = Claims {
+        launch_digest: String::new(),
+        report_data: nonce,
+        signed_data,
+        init_data: Vec::new(),
+        tcb: TcbInfo::Tpm { firmware_version },
+        platform_data: serde_json::json!({}),
+    };
+
+    Ok(tpm_common::build_tpm_verification_result(
+        base_claims,
+        &tpm_pcrs,
+        &tpm_msg,
+        PlatformType::Tpm,
+        report_data_match,
+        None,  // no init_data for bare-metal TPM
+        false, // no collateral verification
+    ))
+}

--- a/src/platforms/tpm_common.rs
+++ b/src/platforms/tpm_common.rs
@@ -404,6 +404,39 @@ pub fn extract_tpm_nonce(message: &[u8]) -> Result<Vec<u8>> {
     Ok(message[offset..offset + nonce_size].to_vec())
 }
 
+/// Extract firmware_version (u64) from TPMS_ATTEST.
+///
+/// Walks past: magic(4) + type(2) + qualifiedSigner(TPM2B) + extraData(TPM2B) +
+/// clockInfo(17) to reach the 8-byte firmwareVersion field.
+pub fn extract_firmware_version(message: &[u8]) -> Result<u64> {
+    let magic = read_be_u32(message, 0, "TPM magic")?;
+    if magic != TPM_ATTEST_MAGIC {
+        return Err(AttestationError::QuoteParseFailed(format!(
+            "invalid TPM Attest magic: 0x{magic:08X}"
+        )));
+    }
+
+    let mut offset = 6; // magic(4) + type(2)
+
+    let signer_size = read_be_u16(message, offset, "qualifiedSigner size")? as usize;
+    offset += 2 + signer_size;
+
+    let nonce_size = read_be_u16(message, offset, "extraData size")? as usize;
+    offset += 2 + nonce_size;
+
+    // clockInfo: clock(8) + resetCount(4) + restartCount(4) + safe(1) = 17 bytes
+    offset += 17;
+
+    if message.len() < offset + 8 {
+        return Err(AttestationError::QuoteParseFailed(
+            "TPM Attest truncated at firmwareVersion".to_string(),
+        ));
+    }
+    Ok(u64::from_be_bytes(
+        message[offset..offset + 8].try_into().unwrap(),
+    ))
+}
+
 /// Verify TPM nonce matches expected report_data.
 pub fn verify_tpm_nonce(message: &[u8], expected: &[u8]) -> Result<()> {
     let nonce = extract_tpm_nonce(message)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,6 +33,14 @@ pub enum PlatformType {
     /// `rtmr_*`, `tee_tcb_svn`) instead.
     #[serde(rename = "gcp-tdx")]
     GcpTdx,
+    /// Bare-metal TPM 2.0 attestation.
+    ///
+    /// Uses the hardware TPM to generate attestation quotes. Works on any
+    /// machine with a TPM 2.0 — no CVM or cloud provider required. The trust
+    /// root is the TPM Attestation Key; for stronger platform identity,
+    /// verify the EK certificate chain against TPM manufacturer roots.
+    #[serde(rename = "tpm")]
+    Tpm,
     #[serde(rename = "dstack")]
     Dstack,
 }
@@ -58,6 +66,7 @@ impl std::fmt::Display for PlatformType {
             PlatformType::AzSnp => write!(f, "az-snp"),
             PlatformType::GcpSnp => write!(f, "gcp-snp"),
             PlatformType::GcpTdx => write!(f, "gcp-tdx"),
+            PlatformType::Tpm => write!(f, "tpm"),
             PlatformType::Dstack => write!(f, "dstack"),
         }
     }
@@ -143,6 +152,10 @@ pub enum TcbInfo {
         /// Raw 16-byte TCB SVN from the quote body.
         #[serde(with = "hex_bytes")]
         tcb_svn: Vec<u8>,
+    },
+    Tpm {
+        /// TPM firmware version from TPMS_ATTEST.firmwareVersion.
+        firmware_version: u64,
     },
 }
 


### PR DESCRIPTION
## Summary
- New `tpm` platform for bare-metal TPM 2.0 attestation via `tss-esapi`
- Generates TPM2_Quote with transient SRK + AK, reads SHA-256 PCR banks 0-23
- Verification reuses existing `tpm_common` utilities (signature, PCR digest, nonce)
- Detection priority: last (catch-all after all TEE platforms)
- Optional EK certificate for platform identity

## Test plan
- [x] `cargo check --features tpm,attest` compiles clean
- [x] `cargo clippy --features tpm,attest` has zero warnings
- [ ] On TPM-equipped host: `attestation-cli attest --platform tpm | attestation-cli verify` round-trips
- [ ] Verify `detect()` returns `Tpm` on a host with only TPM (no SEV-SNP/TDX)