### PR TITLE
fix: avoid Azure vTPM verifier feature conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "az-snp-vtpm",
+ "az-cvm-vtpm",
  "az-tdx-vtpm",
  "base64 0.22.1",
  "cfg-if",
@@ -193,20 +193,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tss-esapi",
  "zerocopy",
-]
-
-[[package]]
-name = "az-snp-vtpm"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3d6071c96b6306e616d98ff18b8f13de2b55f16f494094f16e22f26d985311"
-dependencies = [
- "az-cvm-vtpm",
- "clap",
- "serde",
- "sev",
- "thiserror 2.0.18",
- "ureq",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "az-cvm-vtpm",
- "az-tdx-vtpm",
  "base64 0.22.1",
  "cfg-if",
  "chrono",
@@ -184,7 +183,6 @@ checksum = "de89af1208d16b05ef093680a32a6d8e4dce9146caf30ae6aa6181777907285a"
 dependencies = [
  "jsonwebkey",
  "memoffset",
- "openssl",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -192,21 +190,6 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tss-esapi",
- "zerocopy",
-]
-
-[[package]]
-name = "az-tdx-vtpm"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68381aac2d985b3482b67aa9766b0a5c97afcb7e794815871b824d7766cca56b"
-dependencies = [
- "az-cvm-vtpm",
- "base64-url",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "ureq",
  "zerocopy",
 ]
 
@@ -233,15 +216,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-url"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b761ea69df72d0cc9591ea39adfb0e3b922a27dc535227d7ffbed5702e8809"
-dependencies = [
- "base64 0.22.1",
-]
 
 [[package]]
 name = "base64ct"
@@ -429,35 +403,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -657,15 +602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,21 +711,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1342,12 +1263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,44 +1434,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1925,15 +1802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,9 +2123,7 @@ dependencies = [
  "iocuddle",
  "lazy_static",
  "libc",
- "openssl",
  "p384",
- "rdrand",
  "rsa",
  "sha2",
  "static_assertions",
@@ -2695,34 +2561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64 0.22.1",
- "cookie_store",
- "log",
- "percent-encoding",
- "serde",
- "serde_json",
- "ureq-proto",
- "utf8-zero",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64 0.22.1",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,12 +2571,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -2762,12 +2594,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ dstack = ["tdx"]       # dstack proxies TDX quotes via Unix socket
 
 # Guest-side evidence generation (Linux-only, requires TEE hardware).
 # Combine with platform features for per-platform builds:
-#   attest + snp           → bare-metal SNP attestation only
-#   az-snp-attest          → Azure SNP attestation over Azure vTPM
-#   az-tdx-attest          → Azure TDX attestation over Azure vTPM
-#   attest (+ defaults)    → bare-metal + GCP attesters.
+#   attest                 → default SEV-SNP + TDX attestation set
+#   attest + az-snp        → Azure SNP attestation over Azure vTPM
+#   attest + az-tdx        → Azure TDX attestation over Azure vTPM
+#   attest (+ defaults)    → bare-metal + Azure + GCP attesters.
 #
-# Azure vTPM attesters are separate from generic `attest` so bare-metal and GCP
-# attester builds do not pull TPM/TSS dependencies. They use az-cvm-vtpm
-# directly with default features disabled to avoid the verifier/OpenSSL path.
-attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:zerocopy"]
-az-snp-attest = ["attest", "az-snp", "dep:az-cvm-vtpm"]
-az-tdx-attest = ["attest", "az-tdx", "dep:az-cvm-vtpm"]
+# Azure vTPM attesters use az-cvm-vtpm directly with default features disabled
+# to avoid the verifier/OpenSSL path while composing with the combined SNP/TDX
+# attestation-service feature set.
+attest = ["snp", "tdx", "dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:az-cvm-vtpm", "dep:zerocopy"]
+az-snp-attest = ["attest", "az-snp"] # Compatibility alias; use `attest` + `az-snp`.
+az-tdx-attest = ["attest", "az-tdx"] # Compatibility alias; use `attest` + `az-tdx`.
 
 # CLI binary (verify works everywhere; combine with `attest` for evidence generation)
 cli = ["dep:clap"]
@@ -123,7 +123,7 @@ required-features = ["az-tdx"]
 [[bench]]
 name = "az_snp_attest"
 harness = false
-required-features = ["az-snp-attest"]
+required-features = ["attest", "az-snp"]
 
 [[example]]
 name = "snp"
@@ -135,11 +135,11 @@ required-features = ["attest", "tdx"]
 
 [[example]]
 name = "az_snp"
-required-features = ["az-snp-attest"]
+required-features = ["attest", "az-snp"]
 
 [[example]]
 name = "az_tdx"
-required-features = ["az-tdx-attest"]
+required-features = ["attest", "az-tdx"]
 
 [[example]]
 name = "gcp_snp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,25 +24,16 @@ dstack = ["tdx"]       # dstack proxies TDX quotes via Unix socket
 # Guest-side evidence generation (Linux-only, requires TEE hardware).
 # Combine with platform features for per-platform builds:
 #   attest + snp           → bare-metal SNP attestation only
-#   attest + az-snp-attest → Azure SNP attestation (pulls az-snp-vtpm)
-#   attest (+ defaults)    → bare-metal + GCP attesters only.
+#   attest + az-snp        → Azure SNP attestation over Azure vTPM
+#   az-tdx-attest          → Azure TDX attestation over Azure vTPM
+#   attest (+ defaults)    → bare-metal + Azure SNP + GCP attesters.
 #
-# Azure vTPM attesters are opt-in (not folded into `attest`) because
-# az-snp-vtpm / az-tdx-vtpm 0.8.x pull az-cvm-vtpm *with default features*
-# (their own Cargo.toml omits `default-features = false`), and
-# az-cvm-vtpm's default feature set includes `verifier`, which enables
-# sev/openssl. sev 7 refuses to compile with both openssl and
-# crypto_nossl, and crypto_nossl is required for the WASM verifier build.
-# Setting `default-features = false` on our side of the az-*-vtpm deps
-# does not help — Cargo cannot disable a default feature enabled by a
-# transitive dependent.
-#
-# Long-term fix is upstream: kinvolk/azure-cvm-tooling should propagate
-# `default-features = false` on its az-cvm-vtpm dep in az-snp-vtpm and
-# az-tdx-vtpm. Until then, the opt-in split keeps the generic `attest`
-# build free of the sev/openssl pull.
-attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:zerocopy"]
-az-snp-attest = ["attest", "az-snp", "dep:az-snp-vtpm"]
+# Azure SNP uses az-cvm-vtpm directly with default features disabled, so it can
+# live in the generic `attest` build without pulling the verifier/OpenSSL path.
+# Azure TDX remains opt-in because az-tdx-vtpm still enables az-cvm-vtpm's
+# default verifier feature transitively.
+attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:az-cvm-vtpm", "dep:zerocopy"]
+az-snp-attest = ["attest", "az-snp"] # Compatibility alias; use `attest` + `az-snp`.
 az-tdx-attest = ["attest", "az-tdx", "dep:az-tdx-vtpm"]
 
 # CLI binary (verify works everywhere; combine with `attest` for evidence generation)
@@ -98,7 +89,7 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "time", "net", "io-
 
 # Guest-side attestation crates — Linux-only (require TEE hardware / vTPM)
 [target.'cfg(target_os = "linux")'.dependencies]
-az-snp-vtpm = { version = "0.8.1", default-features = false, features = ["attester"], optional = true }
+az-cvm-vtpm = { version = "0.8.1", default-features = false, features = ["attester"], optional = true }
 az-tdx-vtpm = { version = "0.8", default-features = false, features = ["attester"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -134,7 +125,7 @@ required-features = ["az-tdx"]
 [[bench]]
 name = "az_snp_attest"
 harness = false
-required-features = ["az-snp-attest"]
+required-features = ["attest", "az-snp"]
 
 [[example]]
 name = "snp"
@@ -146,7 +137,7 @@ required-features = ["attest", "tdx"]
 
 [[example]]
 name = "az_snp"
-required-features = ["az-snp-attest"]
+required-features = ["attest", "az-snp"]
 
 [[example]]
 name = "az_tdx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,17 @@ dstack = ["tdx"]       # dstack proxies TDX quotes via Unix socket
 # Guest-side evidence generation (Linux-only, requires TEE hardware).
 # Combine with platform features for per-platform builds:
 #   attest + snp           → bare-metal SNP attestation only
-#   attest + az-snp        → Azure SNP attestation over Azure vTPM
+#   az-snp-attest          → Azure SNP attestation over Azure vTPM
 #   az-tdx-attest          → Azure TDX attestation over Azure vTPM
-#   attest (+ defaults)    → bare-metal + Azure SNP + GCP attesters.
+#   attest (+ defaults)    → bare-metal + GCP attesters.
 #
-# Azure SNP uses az-cvm-vtpm directly with default features disabled, so it can
-# live in the generic `attest` build without pulling the verifier/OpenSSL path.
-# Azure TDX remains opt-in because az-tdx-vtpm still enables az-cvm-vtpm's
+# Azure vTPM attesters are separate from generic `attest` so bare-metal and GCP
+# attester builds do not pull TPM/TSS dependencies. Azure SNP uses az-cvm-vtpm
+# directly with default features disabled to avoid the verifier/OpenSSL path.
+# Azure TDX remains separate because az-tdx-vtpm still enables az-cvm-vtpm's
 # default verifier feature transitively.
-attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:az-cvm-vtpm", "dep:zerocopy"]
-az-snp-attest = ["attest", "az-snp"] # Compatibility alias; use `attest` + `az-snp`.
+attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:zerocopy"]
+az-snp-attest = ["attest", "az-snp", "dep:az-cvm-vtpm"]
 az-tdx-attest = ["attest", "az-tdx", "dep:az-tdx-vtpm"]
 
 # CLI binary (verify works everywhere; combine with `attest` for evidence generation)
@@ -125,7 +126,7 @@ required-features = ["az-tdx"]
 [[bench]]
 name = "az_snp_attest"
 harness = false
-required-features = ["attest", "az-snp"]
+required-features = ["az-snp-attest"]
 
 [[example]]
 name = "snp"
@@ -137,7 +138,7 @@ required-features = ["attest", "tdx"]
 
 [[example]]
 name = "az_snp"
-required-features = ["attest", "az-snp"]
+required-features = ["az-snp-attest"]
 
 [[example]]
 name = "az_tdx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,11 @@ dstack = ["tdx"]       # dstack proxies TDX quotes via Unix socket
 #   attest (+ defaults)    → bare-metal + GCP attesters.
 #
 # Azure vTPM attesters are separate from generic `attest` so bare-metal and GCP
-# attester builds do not pull TPM/TSS dependencies. Azure SNP uses az-cvm-vtpm
+# attester builds do not pull TPM/TSS dependencies. They use az-cvm-vtpm
 # directly with default features disabled to avoid the verifier/OpenSSL path.
-# Azure TDX remains separate because az-tdx-vtpm still enables az-cvm-vtpm's
-# default verifier feature transitively.
 attest = ["dep:libc", "dep:tempfile", "dep:pem-rfc7468", "dep:zerocopy"]
 az-snp-attest = ["attest", "az-snp", "dep:az-cvm-vtpm"]
-az-tdx-attest = ["attest", "az-tdx", "dep:az-tdx-vtpm"]
+az-tdx-attest = ["attest", "az-tdx", "dep:az-cvm-vtpm"]
 
 # CLI binary (verify works everywhere; combine with `attest` for evidence generation)
 cli = ["dep:clap"]
@@ -91,7 +89,6 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "time", "net", "io-
 # Guest-side attestation crates — Linux-only (require TEE hardware / vTPM)
 [target.'cfg(target_os = "linux")'.dependencies]
 az-cvm-vtpm = { version = "0.8.1", default-features = false, features = ["attester"], optional = true }
-az-tdx-vtpm = { version = "0.8", default-features = false, features = ["attester"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Each platform has a dedicated example. Run on the appropriate hardware:
 ```bash
 cargo run --example snp     --features "snp,attest"
 cargo run --example tdx     --features "tdx,attest"
-cargo run --example az_snp  --features "attest"
-cargo run --example az_tdx  --features "attest"
+cargo run --example az_snp  --features "az-snp,attest"
+cargo run --example az_tdx  --features "az-tdx,attest"
 cargo run --example gcp_snp --features "gcp-snp,attest"
 cargo run --example gcp_tdx --features "gcp-tdx,attest"
 ```
@@ -119,7 +119,7 @@ cargo run --example gcp_tdx --features "gcp-tdx,attest"
 Azure examples accept an optional nonce argument:
 
 ```bash
-cargo run --example az_snp --features "attest" -- "my-custom-nonce"
+cargo run --example az_snp --features "az-snp,attest" -- "my-custom-nonce"
 ```
 
 GCP examples accept an optional nonce argument:
@@ -277,10 +277,10 @@ cargo test --features gcp-tdx
 cargo test --features dstack
 
 # Integration tests on Azure SNP CVM
-cargo test --test az_snp_live --features "attest" -- --ignored
+cargo test --test az_snp_live --features "az-snp,attest" -- --ignored
 
 # Integration tests on Azure TDX CVM
-cargo test --test az_tdx_live --features "attest" -- --ignored
+cargo test --test az_tdx_live --features "az-tdx,attest" -- --ignored
 
 # Benchmarks
 cargo bench --features snp

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ attestation = { path = ".", features = ["snp", "tdx"] }
 | `gcp-snp` | GCP SEV-SNP non-vTPM support (implies `snp`)                             |
 | `gcp-tdx` | GCP TDX non-vTPM support (implies `tdx`)                                 |
 | `dstack`  | Dstack TDX support via Unix socket (implies `tdx`)                       |
-| `attest` | Enable guest-side evidence generation (Linux-only, requires TEE hardware) |
-| `az-snp-attest` | Enable Azure SNP vTPM evidence generation                         |
-| `az-tdx-attest` | Enable Azure TDX vTPM evidence generation                         |
+| `attest` | Enable guest-side evidence generation for enabled platforms (Linux-only, requires TEE hardware) |
+| `az-snp-attest` | Compatibility alias for `attest` + `az-snp`                      |
+| `az-tdx-attest` | Compatibility alias for `attest` + `az-tdx`                      |
 | `cli`    | Build the `attestation-cli` binary                                        |
 
-All six platform features are enabled by default. Verification is always compiled when a platform feature is enabled. The `attest` feature gates guest-side code that requires hardware access. Azure vTPM attesters use separate feature flags so non-Azure attester builds do not pull TPM/TSS dependencies.
+All six platform features are enabled by default. Verification is always compiled when a platform feature is enabled. The `attest` feature gates guest-side code that requires hardware access and includes the default SEV-SNP + TDX attestation set.
 
 ## Usage
 
@@ -110,8 +110,8 @@ Each platform has a dedicated example. Run on the appropriate hardware:
 ```bash
 cargo run --example snp     --features "snp,attest"
 cargo run --example tdx     --features "tdx,attest"
-cargo run --example az_snp  --features "az-snp-attest"
-cargo run --example az_tdx  --features "az-tdx-attest"
+cargo run --example az_snp  --features "attest"
+cargo run --example az_tdx  --features "attest"
 cargo run --example gcp_snp --features "gcp-snp,attest"
 cargo run --example gcp_tdx --features "gcp-tdx,attest"
 ```
@@ -119,7 +119,7 @@ cargo run --example gcp_tdx --features "gcp-tdx,attest"
 Azure examples accept an optional nonce argument:
 
 ```bash
-cargo run --example az_snp --features "az-snp-attest" -- "my-custom-nonce"
+cargo run --example az_snp --features "attest" -- "my-custom-nonce"
 ```
 
 GCP examples accept an optional nonce argument:
@@ -277,10 +277,10 @@ cargo test --features gcp-tdx
 cargo test --features dstack
 
 # Integration tests on Azure SNP CVM
-cargo test --test az_snp_live --features "az-snp-attest" -- --ignored
+cargo test --test az_snp_live --features "attest" -- --ignored
 
 # Integration tests on Azure TDX CVM
-cargo test --test az_tdx_live --features "az-tdx-attest" -- --ignored
+cargo test --test az_tdx_live --features "attest" -- --ignored
 
 # Benchmarks
 cargo bench --features snp

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ attestation = { path = ".", features = ["snp", "tdx"] }
 | `gcp-tdx` | GCP TDX non-vTPM support (implies `tdx`)                                 |
 | `dstack`  | Dstack TDX support via Unix socket (implies `tdx`)                       |
 | `attest` | Enable guest-side evidence generation (Linux-only, requires TEE hardware) |
+| `az-snp-attest` | Enable Azure SNP vTPM evidence generation                         |
+| `az-tdx-attest` | Enable Azure TDX vTPM evidence generation                         |
 | `cli`    | Build the `attestation-cli` binary                                        |
 
-All six platform features are enabled by default. Verification is always compiled when a platform feature is enabled. The `attest` feature gates all guest-side code that requires hardware access.
+All six platform features are enabled by default. Verification is always compiled when a platform feature is enabled. The `attest` feature gates guest-side code that requires hardware access. Azure vTPM attesters use separate feature flags so non-Azure attester builds do not pull TPM/TSS dependencies.
 
 ## Usage
 
@@ -108,8 +110,8 @@ Each platform has a dedicated example. Run on the appropriate hardware:
 ```bash
 cargo run --example snp     --features "snp,attest"
 cargo run --example tdx     --features "tdx,attest"
-cargo run --example az_snp  --features "az-snp,attest"
-cargo run --example az_tdx  --features "az-tdx,attest"
+cargo run --example az_snp  --features "az-snp-attest"
+cargo run --example az_tdx  --features "az-tdx-attest"
 cargo run --example gcp_snp --features "gcp-snp,attest"
 cargo run --example gcp_tdx --features "gcp-tdx,attest"
 ```
@@ -117,7 +119,7 @@ cargo run --example gcp_tdx --features "gcp-tdx,attest"
 Azure examples accept an optional nonce argument:
 
 ```bash
-cargo run --example az_snp --features "az-snp,attest" -- "my-custom-nonce"
+cargo run --example az_snp --features "az-snp-attest" -- "my-custom-nonce"
 ```
 
 GCP examples accept an optional nonce argument:
@@ -275,10 +277,10 @@ cargo test --features gcp-tdx
 cargo test --features dstack
 
 # Integration tests on Azure SNP CVM
-cargo test --test az_snp_live --features "az-snp,attest" -- --ignored
+cargo test --test az_snp_live --features "az-snp-attest" -- --ignored
 
 # Integration tests on Azure TDX CVM
-cargo test --test az_tdx_live --features "az-tdx,attest" -- --ignored
+cargo test --test az_tdx_live --features "az-tdx-attest" -- --ignored
 
 # Benchmarks
 cargo bench --features snp

--- a/examples/az_snp.rs
+++ b/examples/az_snp.rs
@@ -1,7 +1,7 @@
 //! Azure SNP (vTPM) attestation example.
 //!
 //! Run on an Azure SNP Confidential VM:
-//!   cargo run --example az_snp --features "az-snp,attest"
+//!   cargo run --example az_snp --features "az-snp-attest"
 
 use std::env;
 use std::time::Instant;

--- a/examples/az_snp.rs
+++ b/examples/az_snp.rs
@@ -1,7 +1,7 @@
 //! Azure SNP (vTPM) attestation example.
 //!
 //! Run on an Azure SNP Confidential VM:
-//!   cargo run --example az_snp --features "az-snp-attest"
+//!   cargo run --example az_snp --features "attest"
 
 use std::env;
 use std::time::Instant;

--- a/examples/az_snp.rs
+++ b/examples/az_snp.rs
@@ -1,7 +1,7 @@
 //! Azure SNP (vTPM) attestation example.
 //!
 //! Run on an Azure SNP Confidential VM:
-//!   cargo run --example az_snp --features "attest"
+//!   cargo run --example az_snp --features "az-snp,attest"
 
 use std::env;
 use std::time::Instant;

--- a/examples/az_tdx.rs
+++ b/examples/az_tdx.rs
@@ -1,7 +1,7 @@
 //! Azure TDX (vTPM) attestation example.
 //!
 //! Run on an Azure TDX Confidential VM:
-//!   cargo run --example az_tdx --features "attest"
+//!   cargo run --example az_tdx --features "az-tdx,attest"
 
 use std::env;
 use std::time::Instant;

--- a/examples/az_tdx.rs
+++ b/examples/az_tdx.rs
@@ -1,7 +1,7 @@
 //! Azure TDX (vTPM) attestation example.
 //!
 //! Run on an Azure TDX Confidential VM:
-//!   cargo run --example az_tdx --features "az-tdx,attest"
+//!   cargo run --example az_tdx --features "attest"
 
 use std::env;
 use std::time::Instant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub fn detect() -> Result<PlatformType> {
         return Ok(PlatformType::AzTdx);
     }
 
-    #[cfg(feature = "az-snp")]
+    #[cfg(feature = "az-snp-attest")]
     if platforms::az_snp::attest::is_available() {
         return Ok(PlatformType::AzSnp);
     }
@@ -147,7 +147,7 @@ pub async fn attest(
             serde_json::to_value(&evidence)
                 .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?
         }
-        #[cfg(feature = "az-snp")]
+        #[cfg(feature = "az-snp-attest")]
         PlatformType::AzSnp => {
             let evidence = platforms::az_snp::attest::generate_evidence(report_data).await?;
             serde_json::to_value(&evidence)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub fn detect() -> Result<PlatformType> {
         return Ok(PlatformType::AzTdx);
     }
 
-    #[cfg(feature = "az-snp-attest")]
+    #[cfg(feature = "az-snp")]
     if platforms::az_snp::attest::is_available() {
         return Ok(PlatformType::AzSnp);
     }
@@ -147,7 +147,7 @@ pub async fn attest(
             serde_json::to_value(&evidence)
                 .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?
         }
-        #[cfg(feature = "az-snp-attest")]
+        #[cfg(feature = "az-snp")]
         PlatformType::AzSnp => {
             let evidence = platforms::az_snp::attest::generate_evidence(report_data).await?;
             serde_json::to_value(&evidence)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,12 +63,12 @@ pub use types::*;
 ///
 #[cfg(all(feature = "attest", target_os = "linux"))]
 pub fn detect() -> Result<PlatformType> {
-    #[cfg(feature = "az-tdx-attest")]
+    #[cfg(feature = "az-tdx")]
     if platforms::az_tdx::attest::is_available() {
         return Ok(PlatformType::AzTdx);
     }
 
-    #[cfg(feature = "az-snp-attest")]
+    #[cfg(feature = "az-snp")]
     if platforms::az_snp::attest::is_available() {
         return Ok(PlatformType::AzSnp);
     }
@@ -147,13 +147,13 @@ pub async fn attest(
             serde_json::to_value(&evidence)
                 .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?
         }
-        #[cfg(feature = "az-snp-attest")]
+        #[cfg(feature = "az-snp")]
         PlatformType::AzSnp => {
             let evidence = platforms::az_snp::attest::generate_evidence(report_data).await?;
             serde_json::to_value(&evidence)
                 .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?
         }
-        #[cfg(feature = "az-tdx-attest")]
+        #[cfg(feature = "az-tdx")]
         PlatformType::AzTdx => {
             let evidence = platforms::az_tdx::attest::generate_evidence_with(
                 report_data,

--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -53,6 +53,22 @@ fn quote_to_tpm_quote(q: vtpm::Quote) -> TpmQuote {
     }
 }
 
+async fn get_imds_certs() -> Result<ImdsCertificates> {
+    reqwest::Client::new()
+        .get(IMDS_CERT_URL)
+        .header("Metadata", "true")
+        .send()
+        .await
+        .map_err(|e| AttestationError::CertFetchError(format!("IMDS request failed: {}", e)))?
+        .error_for_status()
+        .map_err(|e| AttestationError::CertFetchError(format!("IMDS returned error: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| {
+            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e))
+        })
+}
+
 /// Generate Azure SNP attestation evidence.
 pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
     // Validate size fits in 64-byte report_data field, but do NOT pad:
@@ -72,19 +88,7 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
     let tpm_quote = quote_to_tpm_quote(quote);
 
     // 3. Fetch VCEK certificate from Azure IMDS
-    let certs: ImdsCertificates = reqwest::Client::new()
-        .get(IMDS_CERT_URL)
-        .header("Metadata", "true")
-        .send()
-        .await
-        .map_err(|e| AttestationError::CertFetchError(format!("IMDS request failed: {}", e)))?
-        .error_for_status()
-        .map_err(|e| AttestationError::CertFetchError(format!("IMDS returned error: {}", e)))?
-        .json()
-        .await
-        .map_err(|e| {
-            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e))
-        })?;
+    let certs = get_imds_certs().await?;
     let vcek_der = pem_to_der(&certs.vcek)?;
 
     // 4. Assemble evidence

--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -1,7 +1,7 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL, Engine};
 use serde::Deserialize;
 
-use az_cvm_vtpm::{hcl, vtpm};
+use az_cvm_vtpm::vtpm;
 
 use crate::error::{AttestationError, Result};
 use crate::platforms::tpm_common::TpmQuote;
@@ -10,6 +10,10 @@ use crate::utils::pad_report_data;
 use super::evidence::AzSnpEvidence;
 
 const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
+const TPMRM_PATH: &str = "/dev/tpmrm0";
+const TPM_PATH: &str = "/dev/tpm0";
+const DMI_SYS_VENDOR_PATH: &str = "/sys/class/dmi/id/sys_vendor";
+const DMI_BOARD_VENDOR_PATH: &str = "/sys/class/dmi/id/board_vendor";
 
 #[derive(Deserialize)]
 struct ImdsCertificates {
@@ -19,21 +23,23 @@ struct ImdsCertificates {
 
 /// Check if Azure SNP platform is available.
 pub fn is_available() -> bool {
-    let report = match vtpm::get_report() {
-        Ok(report) => report,
-        Err(e) => {
-            log::warn!("Azure SNP detection failed: {}", e);
-            return false;
-        }
-    };
+    crate::platforms::snp::attest::is_available() && has_tpm_device() && is_azure_vm()
+}
 
-    match hcl::HclReport::new(report) {
-        Ok(hcl_report) => hcl_report.report_type() == hcl::ReportType::Snp,
-        Err(e) => {
-            log::warn!("Azure SNP HCL report parsing failed: {}", e);
-            false
-        }
-    }
+fn has_tpm_device() -> bool {
+    std::path::Path::new(TPMRM_PATH).exists() || std::path::Path::new(TPM_PATH).exists()
+}
+
+fn is_azure_vm() -> bool {
+    [DMI_SYS_VENDOR_PATH, DMI_BOARD_VENDOR_PATH]
+        .into_iter()
+        .any(|path| match std::fs::read_to_string(path) {
+            Ok(value) => value.trim() == "Microsoft Corporation",
+            Err(e) => {
+                log::debug!("Azure SNP detection: failed to read {path}: {e}");
+                false
+            }
+        })
 }
 
 /// Convert a PEM-encoded certificate to DER bytes.
@@ -51,24 +57,6 @@ fn quote_to_tpm_quote(q: vtpm::Quote) -> TpmQuote {
         message: hex::encode(q.message()),
         pcrs: q.pcrs_sha256().map(hex::encode).collect(),
     }
-}
-
-async fn fetch_vcek_der() -> Result<Vec<u8>> {
-    let certs: ImdsCertificates = reqwest::Client::new()
-        .get(IMDS_CERT_URL)
-        .header("Metadata", "true")
-        .send()
-        .await
-        .map_err(|e| AttestationError::CertFetchError(format!("IMDS request failed: {}", e)))?
-        .error_for_status()
-        .map_err(|e| AttestationError::CertFetchError(format!("IMDS returned error: {}", e)))?
-        .json()
-        .await
-        .map_err(|e| {
-            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e))
-        })?;
-
-    pem_to_der(&certs.vcek)
 }
 
 /// Generate Azure SNP attestation evidence.
@@ -90,7 +78,20 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
     let tpm_quote = quote_to_tpm_quote(quote);
 
     // 3. Fetch VCEK certificate from Azure IMDS
-    let vcek_der = fetch_vcek_der().await?;
+    let certs: ImdsCertificates = reqwest::Client::new()
+        .get(IMDS_CERT_URL)
+        .header("Metadata", "true")
+        .send()
+        .await
+        .map_err(|e| AttestationError::CertFetchError(format!("IMDS request failed: {}", e)))?
+        .error_for_status()
+        .map_err(|e| AttestationError::CertFetchError(format!("IMDS returned error: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| {
+            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e))
+        })?;
+    let vcek_der = pem_to_der(&certs.vcek)?;
 
     // 4. Assemble evidence
     Ok(AzSnpEvidence {

--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -1,6 +1,7 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL, Engine};
+use serde::Deserialize;
 
-use az_snp_vtpm::{imds, is_snp_cvm, vtpm};
+use az_cvm_vtpm::{hcl, vtpm};
 
 use crate::error::{AttestationError, Result};
 use crate::platforms::tpm_common::TpmQuote;
@@ -8,12 +9,28 @@ use crate::utils::pad_report_data;
 
 use super::evidence::AzSnpEvidence;
 
+const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
+
+#[derive(Deserialize)]
+struct ImdsCertificates {
+    #[serde(rename = "vcekCert")]
+    vcek: String,
+}
+
 /// Check if Azure SNP platform is available.
 pub fn is_available() -> bool {
-    match is_snp_cvm() {
-        Ok(is_snp) => is_snp,
+    let report = match vtpm::get_report() {
+        Ok(report) => report,
         Err(e) => {
             log::warn!("Azure SNP detection failed: {}", e);
+            return false;
+        }
+    };
+
+    match hcl::HclReport::new(report) {
+        Ok(hcl_report) => hcl_report.report_type() == hcl::ReportType::Snp,
+        Err(e) => {
+            log::warn!("Azure SNP HCL report parsing failed: {}", e);
             false
         }
     }
@@ -27,13 +44,31 @@ fn pem_to_der(pem: &str) -> Result<Vec<u8>> {
     Ok(der)
 }
 
-/// Convert az-snp-vtpm Quote to our TpmQuote format.
+/// Convert az-cvm-vtpm Quote to our TpmQuote format.
 fn quote_to_tpm_quote(q: vtpm::Quote) -> TpmQuote {
     TpmQuote {
         signature: hex::encode(q.signature()),
         message: hex::encode(q.message()),
         pcrs: q.pcrs_sha256().map(hex::encode).collect(),
     }
+}
+
+async fn fetch_vcek_der() -> Result<Vec<u8>> {
+    let certs: ImdsCertificates = reqwest::Client::new()
+        .get(IMDS_CERT_URL)
+        .header("Metadata", "true")
+        .send()
+        .await
+        .map_err(|e| AttestationError::CertFetchError(format!("IMDS request failed: {}", e)))?
+        .error_for_status()
+        .map_err(|e| AttestationError::CertFetchError(format!("IMDS returned error: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| {
+            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e))
+        })?;
+
+    pem_to_der(&certs.vcek)
 }
 
 /// Generate Azure SNP attestation evidence.
@@ -55,9 +90,7 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
     let tpm_quote = quote_to_tpm_quote(quote);
 
     // 3. Fetch VCEK certificate from Azure IMDS
-    let certs = imds::get_certs()
-        .map_err(|e| AttestationError::CertFetchError(format!("imds::get_certs failed: {}", e)))?;
-    let vcek_der = pem_to_der(&certs.vcek)?;
+    let vcek_der = fetch_vcek_der().await?;
 
     // 4. Assemble evidence
     Ok(AzSnpEvidence {

--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -1,7 +1,7 @@
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL, Engine};
 use serde::Deserialize;
 
-use az_cvm_vtpm::vtpm;
+use az_cvm_vtpm::{hcl, vtpm};
 
 use crate::error::{AttestationError, Result};
 use crate::platforms::tpm_common::TpmQuote;
@@ -10,10 +10,6 @@ use crate::utils::pad_report_data;
 use super::evidence::AzSnpEvidence;
 
 const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
-const TPMRM_PATH: &str = "/dev/tpmrm0";
-const TPM_PATH: &str = "/dev/tpm0";
-const DMI_SYS_VENDOR_PATH: &str = "/sys/class/dmi/id/sys_vendor";
-const DMI_BOARD_VENDOR_PATH: &str = "/sys/class/dmi/id/board_vendor";
 
 #[derive(Deserialize)]
 struct ImdsCertificates {
@@ -23,23 +19,21 @@ struct ImdsCertificates {
 
 /// Check if Azure SNP platform is available.
 pub fn is_available() -> bool {
-    crate::platforms::snp::attest::is_available() && has_tpm_device() && is_azure_vm()
-}
+    let report = match vtpm::get_report() {
+        Ok(report) => report,
+        Err(e) => {
+            log::warn!("Azure SNP detection failed: {}", e);
+            return false;
+        }
+    };
 
-fn has_tpm_device() -> bool {
-    std::path::Path::new(TPMRM_PATH).exists() || std::path::Path::new(TPM_PATH).exists()
-}
-
-fn is_azure_vm() -> bool {
-    [DMI_SYS_VENDOR_PATH, DMI_BOARD_VENDOR_PATH]
-        .into_iter()
-        .any(|path| match std::fs::read_to_string(path) {
-            Ok(value) => value.trim() == "Microsoft Corporation",
-            Err(e) => {
-                log::debug!("Azure SNP detection: failed to read {path}: {e}");
-                false
-            }
-        })
+    match hcl::HclReport::new(report) {
+        Ok(hcl_report) => hcl_report.report_type() == hcl::ReportType::Snp,
+        Err(e) => {
+            log::warn!("Azure SNP HCL report parsing failed: {}", e);
+            false
+        }
+    }
 }
 
 /// Convert a PEM-encoded certificate to DER bytes.

--- a/src/platforms/az_snp/mod.rs
+++ b/src/platforms/az_snp/mod.rs
@@ -1,5 +1,5 @@
 pub mod evidence;
 pub mod verify;
 
-#[cfg(all(feature = "attest", feature = "az-snp", target_os = "linux"))]
+#[cfg(all(feature = "az-snp-attest", target_os = "linux"))]
 pub mod attest;

--- a/src/platforms/az_snp/mod.rs
+++ b/src/platforms/az_snp/mod.rs
@@ -1,5 +1,5 @@
 pub mod evidence;
 pub mod verify;
 
-#[cfg(all(feature = "az-snp-attest", target_os = "linux"))]
+#[cfg(all(feature = "attest", feature = "az-snp", target_os = "linux"))]
 pub mod attest;

--- a/src/platforms/az_tdx/attest.rs
+++ b/src/platforms/az_tdx/attest.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL, Engine};
 
-use az_tdx_vtpm::{hcl, is_tdx_cvm, tdx, vtpm};
+use az_cvm_vtpm::{hcl, tdx, vtpm};
 use zerocopy::IntoBytes;
 
 use crate::error::{AttestationError, Result};
@@ -55,10 +55,18 @@ async fn get_td_quote_from_imds(td_report: &tdx::TdReport) -> Result<Vec<u8>> {
 
 /// Check if Azure TDX platform is available.
 pub fn is_available() -> bool {
-    match is_tdx_cvm() {
-        Ok(is_tdx) => is_tdx,
+    let report = match vtpm::get_report() {
+        Ok(report) => report,
         Err(e) => {
             log::warn!("Azure TDX detection failed: {}", e);
+            return false;
+        }
+    };
+
+    match hcl::HclReport::new(report) {
+        Ok(hcl_report) => hcl_report.report_type() == hcl::ReportType::Tdx,
+        Err(e) => {
+            log::warn!("Azure TDX HCL report parsing failed: {}", e);
             false
         }
     }

--- a/src/platforms/az_tdx/mod.rs
+++ b/src/platforms/az_tdx/mod.rs
@@ -1,5 +1,5 @@
 pub mod evidence;
 pub mod verify;
 
-#[cfg(all(feature = "az-tdx-attest", target_os = "linux"))]
+#[cfg(all(feature = "attest", feature = "az-tdx", target_os = "linux"))]
 pub mod attest;

--- a/tests/az_snp_live.rs
+++ b/tests/az_snp_live.rs
@@ -6,11 +6,11 @@
 //! - Access to Azure IMDS
 //! - Sufficient permissions for TPM access (root or tss group)
 //!
-//! Run with: cargo test --test az_snp_live --features "az-snp-attest" -- --ignored
+//! Run with: cargo test --test az_snp_live --features "attest" -- --ignored
 //!
 //! Tests are #[ignore] by default — run with --ignored to execute on real hardware.
 
-#![cfg(feature = "az-snp-attest")]
+#![cfg(all(feature = "attest", feature = "az-snp"))]
 
 use base64::Engine;
 

--- a/tests/az_snp_live.rs
+++ b/tests/az_snp_live.rs
@@ -10,7 +10,7 @@
 //!
 //! Tests are #[ignore] by default — run with --ignored to execute on real hardware.
 
-#![cfg(feature = "az-snp-attest")]
+#![cfg(all(feature = "attest", feature = "az-snp"))]
 
 use base64::Engine;
 

--- a/tests/az_snp_live.rs
+++ b/tests/az_snp_live.rs
@@ -6,11 +6,11 @@
 //! - Access to Azure IMDS
 //! - Sufficient permissions for TPM access (root or tss group)
 //!
-//! Run with: cargo test --test az_snp_live --features "attest" -- --ignored
+//! Run with: cargo test --test az_snp_live --features "az-snp-attest" -- --ignored
 //!
 //! Tests are #[ignore] by default — run with --ignored to execute on real hardware.
 
-#![cfg(all(feature = "attest", feature = "az-snp"))]
+#![cfg(feature = "az-snp-attest")]
 
 use base64::Engine;
 

--- a/tests/az_snp_live.rs
+++ b/tests/az_snp_live.rs
@@ -6,7 +6,7 @@
 //! - Access to Azure IMDS
 //! - Sufficient permissions for TPM access (root or tss group)
 //!
-//! Run with: cargo test --test az_snp_live --features "attest" -- --ignored
+//! Run with: cargo test --test az_snp_live --features "az-snp,attest" -- --ignored
 //!
 //! Tests are #[ignore] by default — run with --ignored to execute on real hardware.
 

--- a/tests/az_tdx_live.rs
+++ b/tests/az_tdx_live.rs
@@ -10,7 +10,7 @@
 //!
 //! Tests are #[ignore] by default — run with --ignored to execute on real hardware.
 
-#![cfg(feature = "az-tdx-attest")]
+#![cfg(all(feature = "attest", feature = "az-tdx"))]
 
 use base64::Engine;
 

--- a/tests/az_tdx_live.rs
+++ b/tests/az_tdx_live.rs
@@ -6,7 +6,7 @@
 //! - Access to Azure IMDS
 //! - Sufficient permissions for TPM access (root or tss group)
 //!
-//! Run with: cargo test --test az_tdx_live --features "attest" -- --ignored
+//! Run with: cargo test --test az_tdx_live --features "az-tdx,attest" -- --ignored
 //!
 //! Tests are #[ignore] by default — run with --ignored to execute on real hardware.
 

--- a/tests/capture_fixture.rs
+++ b/tests/capture_fixture.rs
@@ -50,7 +50,7 @@ async fn capture_tdx_evidence_fixture() {
     }
 }
 
-#[cfg(feature = "az-snp")]
+#[cfg(feature = "az-snp-attest")]
 #[tokio::test]
 #[ignore]
 async fn capture_az_snp_evidence_fixture() {

--- a/tests/capture_fixture.rs
+++ b/tests/capture_fixture.rs
@@ -50,7 +50,7 @@ async fn capture_tdx_evidence_fixture() {
     }
 }
 
-#[cfg(feature = "az-snp-attest")]
+#[cfg(all(feature = "attest", feature = "az-snp"))]
 #[tokio::test]
 #[ignore]
 async fn capture_az_snp_evidence_fixture() {
@@ -79,7 +79,7 @@ async fn capture_az_snp_evidence_fixture() {
     assert!(result.signature_valid);
 }
 
-#[cfg(feature = "az-tdx-attest")]
+#[cfg(all(feature = "attest", feature = "az-tdx"))]
 #[tokio::test]
 #[ignore]
 async fn capture_az_tdx_evidence_fixture() {

--- a/tests/capture_fixture.rs
+++ b/tests/capture_fixture.rs
@@ -50,7 +50,7 @@ async fn capture_tdx_evidence_fixture() {
     }
 }
 
-#[cfg(feature = "az-snp-attest")]
+#[cfg(feature = "az-snp")]
 #[tokio::test]
 #[ignore]
 async fn capture_az_snp_evidence_fixture() {


### PR DESCRIPTION
## Summary
- switch Azure SNP evidence generation to use az-cvm-vtpm's attester path directly
- switch Azure TDX evidence generation to use az-cvm-vtpm directly instead of az-tdx-vtpm
- fetch the Azure SNP VCEK from IMDS with reqwest instead of pulling az-snp-vtpm
- make `attest` load the combined SEV-SNP + TDX guest-attestation set; with default platform features, Azure and GCP attesters are available from `attest`
- keep `az-snp-attest` / `az-tdx-attest` as compatibility aliases for `attest` + the matching Azure platform feature
- avoid the transitive az-cvm-vtpm verifier/OpenSSL path that conflicts with attestation-rs' `sev/crypto_nossl` build in the combined attestation-service feature set

## Validation
- cargo fmt --check
- cargo check --features attest
- cargo tree --target all -e features --features attest -i sev
- cargo check --features az-snp-attest
- cargo check --features az-tdx-attest
- cargo check --features cli,attest
- cargo test --lib --features attest
- cargo check --no-default-features --features attest
- cargo check --no-default-features --features attest,az-snp
- cargo check --no-default-features --features attest,az-tdx
- cargo tree --target all -e features --no-default-features --features attest -i sev
