### PR TITLE
force az_snp report data to the size that will actually work

### DIFF
--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -38,18 +38,16 @@ fn quote_to_tpm_quote(q: vtpm::Quote) -> TpmQuote {
 
 /// Generate Azure SNP attestation evidence.
 pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
-    // Validate size fits in 64-byte report_data field, but do NOT pad:
-    // TPM2B_DATA (used by vtpm::get_quote) has a smaller max size than 64 bytes
-    // on Azure vTPMs, so we must pass the original unpadded data as the nonce.
-    let _ = pad_report_data(report_data, 64)?;
+    // TPM2B_DATA (used by vtpm::get_quote) has max size of 50 bytes on Azure vTPMs
+    let report_data = pad_report_data(report_data, 50)?;
 
     // 1. Read HCL report from vTPM NVRAM
     let hcl_report_bytes = vtpm::get_report().map_err(|e| {
         AttestationError::HardwareAccessFailed(format!("vtpm::get_report failed: {}", e))
     })?;
 
-    // 2. Generate TPM quote with report_data as nonce (unpadded)
-    let quote = vtpm::get_quote(report_data).map_err(|e| {
+    // 2. Generate TPM quote with report_data as nonce
+    let quote = vtpm::get_quote(&report_data).map_err(|e| {
         AttestationError::HardwareAccessFailed(format!("vtpm::get_quote failed: {}", e))
     })?;
     let tpm_quote = quote_to_tpm_quote(quote);


### PR DESCRIPTION
rather than accept a report_data that contains too many bytes and explode when those bytes are passed to the underlying vTPM for quote generation, actually verify/pad until we have exactly the number of bytes that az-snp supports: 50.