### PR TITLE
Detect based on the device we actually open

### DIFF
--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -19,7 +19,7 @@ struct ImdsCertificates {
 
 /// Check if Azure SNP platform is available.
 pub fn is_available() -> bool {
-    if !crate::platforms::tpm_common::vtpm_device_openable() {
+    if !crate::platforms::tpm_common::azure_vtpm_available() {
         return false;
     }
     let report = match vtpm::get_report() {

--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use az_cvm_vtpm::{hcl, vtpm};
 
 use crate::error::{AttestationError, Result};
-use crate::platforms::tpm_common::TpmQuote;
+use crate::platforms::tpm_common::{azure_vtpm_available, TpmQuote};
 use crate::utils::pad_report_data;
 
 use super::evidence::AzSnpEvidence;
@@ -19,7 +19,7 @@ struct ImdsCertificates {
 
 /// Check if Azure SNP platform is available.
 pub fn is_available() -> bool {
-    if !crate::platforms::tpm_common::azure_vtpm_available() {
+    if !azure_vtpm_available() {
         return false;
     }
     let report = match vtpm::get_report() {

--- a/src/platforms/az_snp/attest.rs
+++ b/src/platforms/az_snp/attest.rs
@@ -19,6 +19,9 @@ struct ImdsCertificates {
 
 /// Check if Azure SNP platform is available.
 pub fn is_available() -> bool {
+    if !crate::platforms::tpm_common::vtpm_device_openable() {
+        return false;
+    }
     let report = match vtpm::get_report() {
         Ok(report) => report,
         Err(e) => {

--- a/src/platforms/az_tdx/attest.rs
+++ b/src/platforms/az_tdx/attest.rs
@@ -55,6 +55,9 @@ async fn get_td_quote_from_imds(td_report: &tdx::TdReport) -> Result<Vec<u8>> {
 
 /// Check if Azure TDX platform is available.
 pub fn is_available() -> bool {
+    if !crate::platforms::tpm_common::vtpm_device_openable() {
+        return false;
+    }
     let report = match vtpm::get_report() {
         Ok(report) => report,
         Err(e) => {

--- a/src/platforms/az_tdx/attest.rs
+++ b/src/platforms/az_tdx/attest.rs
@@ -55,7 +55,7 @@ async fn get_td_quote_from_imds(td_report: &tdx::TdReport) -> Result<Vec<u8>> {
 
 /// Check if Azure TDX platform is available.
 pub fn is_available() -> bool {
-    if !crate::platforms::tpm_common::vtpm_device_openable() {
+    if !crate::platforms::tpm_common::azure_vtpm_available() {
         return false;
     }
     let report = match vtpm::get_report() {

--- a/src/platforms/az_tdx/attest.rs
+++ b/src/platforms/az_tdx/attest.rs
@@ -6,7 +6,7 @@ use az_cvm_vtpm::{hcl, tdx, vtpm};
 use zerocopy::IntoBytes;
 
 use crate::error::{AttestationError, Result};
-use crate::platforms::tpm_common::TpmQuote;
+use crate::platforms::tpm_common::{azure_vtpm_available, TpmQuote};
 use crate::utils::pad_report_data;
 
 use super::evidence::AzTdxEvidence;
@@ -55,7 +55,7 @@ async fn get_td_quote_from_imds(td_report: &tdx::TdReport) -> Result<Vec<u8>> {
 
 /// Check if Azure TDX platform is available.
 pub fn is_available() -> bool {
-    if !crate::platforms::tpm_common::azure_vtpm_available() {
+    if !azure_vtpm_available() {
         return false;
     }
     let report = match vtpm::get_report() {

--- a/src/platforms/dstack/verify.rs
+++ b/src/platforms/dstack/verify.rs
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn base64_input_is_returned_unchanged() {
         // Real base64 contains characters like +, /, = that fail hex::decode
-        let b64_input = BASE64.encode(&vec![0xFFu8; 700]);
+        let b64_input = BASE64.encode(vec![0xFFu8; 700]);
         let result = normalize_quote_to_base64(&b64_input);
         assert_eq!(result, b64_input);
     }

--- a/src/platforms/gcp_snp/attest.rs
+++ b/src/platforms/gcp_snp/attest.rs
@@ -6,7 +6,8 @@
 use crate::error::Result;
 use crate::platforms::snp::evidence::SnpEvidence;
 
-const SEV_PLATFORM_PATH: &str = "/sys/devices/platform/sev-guest";
+/// SNP guest attestation character device — the device attestation opens.
+const SEV_GUEST_DEVICE_PATH: &str = "/dev/sev-guest";
 const DMI_BOARD_VENDOR_PATH: &str = "/sys/class/dmi/id/board_vendor";
 
 /// Check if we are running on a GCP Confidential VM with SNP.
@@ -23,7 +24,7 @@ const DMI_BOARD_VENDOR_PATH: &str = "/sys/class/dmi/id/board_vendor";
 /// is cryptographically valid AMD SNP evidence, but the `GcpSnp` platform tag
 /// in the envelope reflects the attester's self-classification only.
 pub fn is_available() -> bool {
-    if !std::path::Path::new(SEV_PLATFORM_PATH).exists() {
+    if !std::path::Path::new(SEV_GUEST_DEVICE_PATH).exists() {
         return false;
     }
     match std::fs::read_to_string(DMI_BOARD_VENDOR_PATH) {

--- a/src/platforms/gcp_snp/attest.rs
+++ b/src/platforms/gcp_snp/attest.rs
@@ -3,6 +3,8 @@
 // bare-metal SNP implementation. GCP exposes the same /dev/sev-guest device
 // and produces standard AMD SNP attestation reports.
 
+use std::path::Path;
+
 use crate::error::Result;
 use crate::platforms::snp::evidence::SnpEvidence;
 
@@ -24,7 +26,7 @@ const DMI_BOARD_VENDOR_PATH: &str = "/sys/class/dmi/id/board_vendor";
 /// is cryptographically valid AMD SNP evidence, but the `GcpSnp` platform tag
 /// in the envelope reflects the attester's self-classification only.
 pub fn is_available() -> bool {
-    if !std::path::Path::new(SEV_GUEST_DEVICE_PATH).exists() {
+    if !Path::new(SEV_GUEST_DEVICE_PATH).exists() {
         return false;
     }
     match std::fs::read_to_string(DMI_BOARD_VENDOR_PATH) {

--- a/src/platforms/snp/attest.rs
+++ b/src/platforms/snp/attest.rs
@@ -8,11 +8,12 @@ use crate::utils::pad_report_data;
 
 use super::evidence::{SnpCertChain, SnpEvidence};
 
-const SEV_PLATFORM_PATH: &str = "/sys/devices/platform/sev-guest";
+/// SNP guest attestation character device.
+const SEV_GUEST_DEVICE_PATH: &str = "/dev/sev-guest";
 
 /// Check if SNP hardware is available on this machine.
 pub fn is_available() -> bool {
-    std::path::Path::new(SEV_PLATFORM_PATH).exists()
+    std::path::Path::new(SEV_GUEST_DEVICE_PATH).exists()
 }
 
 /// Extract certificates from the sev crate's cert table entries.

--- a/src/platforms/snp/attest.rs
+++ b/src/platforms/snp/attest.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 
 use sev::firmware::guest::Firmware;
@@ -13,7 +15,7 @@ const SEV_GUEST_DEVICE_PATH: &str = "/dev/sev-guest";
 
 /// Check if SNP hardware is available on this machine.
 pub fn is_available() -> bool {
-    std::path::Path::new(SEV_GUEST_DEVICE_PATH).exists()
+    Path::new(SEV_GUEST_DEVICE_PATH).exists()
 }
 
 /// Extract certificates from the sev crate's cert table entries.

--- a/src/platforms/tdx/attest.rs
+++ b/src/platforms/tdx/attest.rs
@@ -413,7 +413,7 @@ fn vsock_send_receive(request: &[u8]) -> Result<Vec<u8>> {
 
     let body_size = u32::from_be_bytes(size_buf) as usize;
 
-    if body_size < 16 || body_size > 65536 {
+    if !(16..=65536).contains(&body_size) {
         return Err(AttestationError::HardwareAccessFailed(format!(
             "vsock response body size out of range: {}",
             body_size

--- a/src/platforms/tpm_common.rs
+++ b/src/platforms/tpm_common.rs
@@ -11,6 +11,28 @@ use crate::utils::strip_trailing_nulls;
 /// Decoded TPM quote components: (signature, message, pcr_values).
 pub type DecodedTpmQuote = (Vec<u8>, Vec<u8>, Vec<Vec<u8>>);
 
+/// The vTPM device path `az_cvm_vtpm` opens (`TctiNameConf::Device` default).
+const VTPM_DEVICE_PATH: &str = "/dev/tpm0";
+
+/// Probe whether the vTPM device can actually be opened.
+///
+/// `az_cvm_vtpm` builds its context with `TctiNameConf::Device`, whose
+/// default path is `/dev/tpm0`. When that device is missing *or* present
+/// but not openable (e.g. owned by `tss` with no access for the caller),
+/// the tss2 C library logs `ERROR:tcti:...` lines straight to stderr.
+///
+/// Probing the open ourselves — read+write, matching the tcti-device
+/// driver — lets platform detection skip `vtpm::get_report()` cleanly when
+/// the call could only fail noisily. The handle is dropped immediately so
+/// it does not contend with the library's own open of the same device.
+pub fn vtpm_device_openable() -> bool {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(VTPM_DEVICE_PATH)
+        .is_ok()
+}
+
 // --- TPM algorithm constants ---
 
 /// TPM_ALG_RSA

--- a/src/platforms/tpm_common.rs
+++ b/src/platforms/tpm_common.rs
@@ -4,6 +4,9 @@ use rsa::signature::Verifier;
 use rsa::RsaPublicKey;
 use serde::{Deserialize, Serialize};
 
+#[cfg(all(feature = "attest", target_os = "linux"))]
+use std::sync::Once;
+
 use crate::error::{AttestationError, Result};
 use crate::types::{Claims, PlatformType, VerificationResult};
 use crate::utils::strip_trailing_nulls;
@@ -12,25 +15,59 @@ use crate::utils::strip_trailing_nulls;
 pub type DecodedTpmQuote = (Vec<u8>, Vec<u8>, Vec<Vec<u8>>);
 
 /// The vTPM device path `az_cvm_vtpm` opens (`TctiNameConf::Device` default).
+#[cfg(all(feature = "attest", target_os = "linux"))]
 const VTPM_DEVICE_PATH: &str = "/dev/tpm0";
 
-/// Probe whether the vTPM device can actually be opened.
+/// Azure sets this fixed value on all its VMs
+#[cfg(all(feature = "attest", target_os = "linux"))]
+const AZURE_CHASSIS_ASSET_TAG: &str = "7783-7084-3265-9085-8269-3286-77";
+
+/// Whether an Azure vTPM is present and usable for SNP/TDX detection.
 ///
-/// `az_cvm_vtpm` builds its context with `TctiNameConf::Device`, whose
-/// default path is `/dev/tpm0`. When that device is missing *or* present
-/// but not openable (e.g. owned by `tss` with no access for the caller),
-/// the tss2 C library logs `ERROR:tcti:...` lines straight to stderr.
-///
-/// Probing the open ourselves — read+write, matching the tcti-device
-/// driver — lets platform detection skip `vtpm::get_report()` cleanly when
-/// the call could only fail noisily. The handle is dropped immediately so
-/// it does not contend with the library's own open of the same device.
-pub fn vtpm_device_openable() -> bool {
-    std::fs::OpenOptions::new()
+/// For mysterious reasons, Azure offers TEE attestation via a vTPM,
+/// at device `/dev/tmp0`, exactly like a real bare metal machine with
+/// a real TPM. To avoid sending Azure TEE messages to the real TPMs and
+/// causing ERROR log lines, we see if we are on an Azure VM first.
+#[cfg(all(feature = "attest", target_os = "linux"))]
+pub fn azure_vtpm_available() -> bool {
+    is_azure_cvm() && vtpm_device_accessible()
+}
+
+#[cfg(all(feature = "attest", target_os = "linux"))]
+fn is_azure_cvm() -> bool {
+    std::fs::read_to_string("/sys/class/dmi/id/chassis_asset_tag")
+        .map(|tag| tag.trim() == AZURE_CHASSIS_ASSET_TAG)
+        .unwrap_or(false)
+}
+
+#[cfg(all(feature = "attest", target_os = "linux"))]
+static WARN_FOUND: Once = Once::new();
+
+/// Whether the vTPM device exists and is readable/writable.
+/// Warns if we can see a device but don't have permissions.
+/// Uses a Once guard to avoid one warning each for snp and tdx.
+#[cfg(all(feature = "attest", target_os = "linux"))]
+fn vtpm_device_accessible() -> bool {
+    let access = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open(VTPM_DEVICE_PATH)
-        .is_ok()
+        .open(VTPM_DEVICE_PATH);
+    let access_ok = access.is_ok();
+
+    if access.is_err() {
+        let exists = std::fs::exists(VTPM_DEVICE_PATH).unwrap_or(false);
+        if exists {
+            WARN_FOUND.call_once(|| {
+                let e = access.unwrap_err();
+                eprintln!(
+                    "WARNING: found TPM device {} with error {}",
+                    VTPM_DEVICE_PATH, e
+                )
+            });
+        }
+    };
+
+    access_ok
 }
 
 // --- TPM algorithm constants ---

--- a/tests/az_snp_live.rs
+++ b/tests/az_snp_live.rs
@@ -12,6 +12,8 @@
 
 #![cfg(all(feature = "attest", feature = "az-snp"))]
 
+use std::path::Path;
+
 use base64::Engine;
 
 use attestation::types::VerifyParams;
@@ -19,8 +21,7 @@ use attestation::types::VerifyParams;
 /// Helper: check if we're running on an Azure SNP CVM with the required tools.
 fn is_az_snp_cvm() -> bool {
     // Check for TPM device
-    let has_tpm =
-        std::path::Path::new("/dev/tpmrm0").exists() || std::path::Path::new("/dev/tpm0").exists();
+    let has_tpm = Path::new("/dev/tpmrm0").exists() || Path::new("/dev/tpm0").exists();
 
     // Check for Azure environment via IMDS (more reliable than file checks)
     let is_azure = std::process::Command::new("curl")

--- a/tests/az_tdx_live.rs
+++ b/tests/az_tdx_live.rs
@@ -12,6 +12,8 @@
 
 #![cfg(all(feature = "attest", feature = "az-tdx"))]
 
+use std::path::Path;
+
 use base64::Engine;
 
 use attestation::types::VerifyParams;
@@ -19,8 +21,7 @@ use attestation::types::VerifyParams;
 /// Helper: check if we're running on an Azure TDX CVM with the required tools.
 fn is_az_tdx_cvm() -> bool {
     // Check for TPM device
-    let has_tpm =
-        std::path::Path::new("/dev/tpmrm0").exists() || std::path::Path::new("/dev/tpm0").exists();
+    let has_tpm = Path::new("/dev/tpmrm0").exists() || Path::new("/dev/tpm0").exists();
 
     // Check for Azure environment via IMDS (more reliable than file checks)
     let is_azure = std::process::Command::new("curl")


### PR DESCRIPTION
This fixes a bug where `attestation-cli detect` would report it found `snp`, but then `attestation-cli attest` would fail. This is  because the detection and the attestation were using completely different paths, so detect could succeed and then attest would fail.

Detecting on the device path (rather than the `/sys/devices/platform/sev-guest` platform directory) ensures `is_available` only reports `true` when attestation can succeed: the platform device is created by any SNP-guest init, but doesn't guarantee there's a `/dev/sev-guest` we can use to attest.