### PR TITLE
fix(attestation): memoize platform detection

### DIFF
--- a/crates/attestation-api/src/api/health.rs
+++ b/crates/attestation-api/src/api/health.rs
@@ -20,6 +20,8 @@ pub struct CacheStats {
 }
 
 pub async fn handler(State(state): State<AppState>) -> Json<HealthResponse> {
+    // attestation::detect() memoizes the hardware probe, so calling it per
+    // request here does not re-open the vTPM context.
     let platform = {
         #[cfg(target_os = "linux")]
         {

--- a/crates/attestation-api/src/main.rs
+++ b/crates/attestation-api/src/main.rs
@@ -96,6 +96,12 @@ async fn main() -> anyhow::Result<()> {
             .with_tdx_provider(tdx_provider),
     );
 
+    // Warm attestation::detect()'s process-lifetime cache before serving, so the
+    // first /health/attest/platform request hits the memoized value instead of
+    // racing to open the vTPM context.
+    #[cfg(target_os = "linux")]
+    let _ = attestation::detect();
+
     let state = AppState {
         config,
         cert_cache,

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -27,6 +27,9 @@
 //! let evidence_json = attestation::attest(platform, b"nonce", &attestation::AttestOptions::default()).await?;
 //! ```
 
+#[cfg(all(feature = "attest", target_os = "linux"))]
+use std::sync::OnceLock;
+
 pub mod collateral;
 pub mod error;
 pub mod platforms;
@@ -61,8 +64,27 @@ pub use types::*;
 ///
 /// Order: `az-tdx` → `az-snp` → `gcp-tdx` → `gcp-snp` → `tdx` → `snp`
 ///
+/// The result is memoized: the underlying hardware probes (which open a vTPM
+/// context on vTPM-backed platforms) run once for the process, so callers on
+/// hot paths — `/health` probes, `/attest`, `/platform` — do not re-probe the
+/// device on every request.
 #[cfg(all(feature = "attest", target_os = "linux"))]
 pub fn detect() -> Result<PlatformType> {
+    // OnceLock holds Option: Some(platform) on detection, None when no platform
+    // is present. Both outcomes are static for the process — hardware does not
+    // appear or vanish at runtime — so caching either is sound. (Result is not
+    // cached directly because AttestationError is not Clone.)
+    static DETECTED: OnceLock<Option<PlatformType>> = OnceLock::new();
+    match DETECTED.get_or_init(|| detect_uncached().ok()) {
+        Some(platform) => Ok(*platform),
+        None => Err(AttestationError::NoPlatformDetected),
+    }
+}
+
+/// Probe the hardware for the current TEE platform. Uncached; [`detect`] wraps
+/// this with process-lifetime memoization.
+#[cfg(all(feature = "attest", target_os = "linux"))]
+fn detect_uncached() -> Result<PlatformType> {
     #[cfg(feature = "az-tdx")]
     if platforms::az_tdx::attest::is_available() {
         return Ok(PlatformType::AzTdx);


### PR DESCRIPTION
## What

`attestation::detect()` probed the hardware on every call. On the Azure SEV-SNP/TDX path that opens a vTPM context, so `/health`, `/platform`, and `/attest` each re-probed the device per request and serialised under kubelet probe load on managed CVM, flapping the service.

Memoize the detection result in a `OnceLock`: the probe runs once per process (the platform is static for the process lifetime — hardware does not appear or vanish at runtime), and every caller gets the cached outcome. The `detect()` signature is unchanged; the body is split into a memoizing wrapper plus an uncached `detect_uncached()`.

## Why it matters

A flapping attestation-api takes down dependents: the per-node NRI image-policy worker does an attested RA-TLS pull through it, so an unhealthy `/health` cascaded into that plugin failing to start.

## Test

- `attestation` crate: 156 passed.
- `/health` tests pass; response shape unchanged.
- `attest_rejects_disallowed_platform_before_hardware_access` fails on this branch and on clean `main` (pre-existing, unrelated darwin-host failure).
