### PR TITLE
fix(az-snp): pass unpadded report_data as the TPM quote nonce

### DIFF
--- a/crates/attestation/src/platforms/az_snp/attest.rs
+++ b/crates/attestation/src/platforms/az_snp/attest.rs
@@ -74,16 +74,22 @@ async fn get_imds_certs() -> Result<ImdsCertificates> {
 
 /// Generate Azure SNP attestation evidence.
 pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
-    // TPM2B_DATA (used by vtpm::get_quote) has max size of 50 bytes on Azure vTPMs
-    let report_data = pad_report_data(report_data, 50)?;
+    // Validate size fits the Azure vTPM TPM2B_DATA limit (50 bytes, smaller
+    // than the 64-byte SNP report_data field), but do NOT pad: vtpm::get_quote
+    // puts the data verbatim into the TPM nonce, and the verifier matches the
+    // original unpadded report_data against the unpadded nonce
+    // (tpm_common::verify_tpm_nonce requires equal lengths). Padding here would
+    // make the quote's nonce longer than the expected report_data and fail
+    // verification. Mirrors az_tdx/attest.
+    let _ = pad_report_data(report_data, 50)?;
 
     // 1. Read HCL report from vTPM NVRAM
     let hcl_report_bytes = vtpm::get_report().map_err(|e| {
         AttestationError::HardwareAccessFailed(format!("vtpm::get_report failed: {}", e))
     })?;
 
-    // 2. Generate TPM quote with report_data as nonce
-    let quote = vtpm::get_quote(&report_data).map_err(|e| {
+    // 2. Generate TPM quote with report_data as nonce (unpadded)
+    let quote = vtpm::get_quote(report_data).map_err(|e| {
         AttestationError::HardwareAccessFailed(format!("vtpm::get_quote failed: {}", e))
     })?;
     let tpm_quote = quote_to_tpm_quote(quote);


### PR DESCRIPTION
## Problem

`az_snp::attest::generate_evidence` padded `report_data` to 50 bytes before `vtpm::get_quote`, so the Azure vTPM quote's TPM nonce was 50 bytes. The verifier (`tpm_common::verify_tpm_nonce`) matches that nonce against the caller's original `expected_report_data` and requires equal lengths. Callers send an unpadded 48-byte SHA-384, so verification failed with `quote parsing failed: TPM nonce length mismatch` on every az-snp RA-TLS handshake.

This was introduced by d1294d1 ("force az_snp report data to the size that will actually work"), which padded to 50 to avoid `TPM_RC_SIZE` back when callers sent the full 64-byte report_data (> the 50-byte TPM2B_DATA limit). Callers now send 48 bytes, so the padding is no longer needed and is actively breaking verification. `az_tdx::attest` already handles this correctly (bounds-check only, quote unpadded), and the `tpm_common` nonce regression tests already encode the unpadded contract.

## Change

Use `pad_report_data(report_data, 50)` only as a bounds check and pass the unpadded `report_data` to `vtpm::get_quote`, matching `az_tdx/attest` and the verify-side contract. 48 ≤ 50 fits the TPM2B_DATA limit, so this does not reintroduce `TPM_RC_SIZE`.

## Impact

Fixes az-snp verification end to end (the attest-side nonce now equals the verify-side expected report_data). Observed on a live AKS SEV-SNP cluster: every verification was failing with the length-mismatch error before this.

## Tests

`cargo test -p attestation --features attest --lib` — 156 passed, including the full `tpm_common` nonce suite (`test_check_report_data_unpadded_nonce_matches_original`, `..._rejects_padded_expected`, `test_tpm_nonce_length_mismatch`) which assert exactly this contract.