### PR TITLE
feat: expected tdx measurements

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,17 @@
+# cargo-audit configuration.
+
+[advisories]
+# RUSTSEC-2023-0071 — Marvin attack on `rsa` 0.9.10 (transitive via
+# sev → az-cvm-vtpm). No fixed upgrade is published.
+#
+# Not exploitable in this codebase: the `rsa` crate's PKCS#1 v1.5
+# decryption path is the side-channel target, and we use `rsa` only
+# for RSA-PSS signature *verification* (AMD CRL signing key on the
+# bare-metal SNP path; TPM quote signatures on the Azure vTPM
+# overlays). Verification has no decryption oracle and therefore
+# no Marvin exposure.
+#
+# Watch for an upstream `sev` crate update that drops the rsa
+# dependency or migrates to a fixed version; remove this ignore
+# once the chain is clean.
+ignore = ["RUSTSEC-2023-0071"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/README.md
+++ b/README.md
@@ -98,6 +98,51 @@ For a Node.js end-to-end example (generate live evidence, fetch the VCEK from AM
 KDS, verify in WASM), build with `--target nodejs` and run
 `crates/attestation-wasm/example.mjs`.
 
+## Pinning launch measurements
+
+`VerifyParams` carries optional reference values that the verifier compares
+against the measurement registers in the quote. When the operator supplies a
+value, the corresponding `VerificationResult` field is `Some(true)`/`Some(false)`;
+when omitted the result is `None` (no check requested).
+
+```rust
+use attestation::types::VerifyParams;
+
+let params = VerifyParams {
+    // TDX policy
+    expected_mrtd: Some(mrtd_bytes),                   // [u8; 48]
+    expected_rtmrs: Some([None, Some(rtmr1), Some(rtmr2), None]),
+    // SNP policy
+    expected_launch_digest: Some(launch_digest_bytes), // [u8; 48]
+    // existing fields
+    expected_report_data: Some(nonce.to_vec()),
+    ..Default::default()
+};
+
+let result = attestation::verify(&evidence_json, &params).await?;
+assert_eq!(result.mrtd_match, Some(true));
+assert_eq!(result.rtmr_matches, Some([None, Some(true), Some(true), None]));
+```
+
+All comparisons are constant-time (`subtle::ConstantTimeEq`) and do not
+short-circuit between RTMRs — every populated reference is checked.
+`VerificationResult` carries `#[must_use]` so dropping the result without
+inspecting the policy outcomes is a compile-time warning.
+
+The CLI exposes matching flags:
+
+```bash
+attestation-cli verify \
+  --evidence evidence.json \
+  --expected-mrtd $MRTD \
+  --expected-rtmr1 $RTMR1 \
+  --expected-rtmr2 $RTMR2
+# exit 0 on full match; exit 1 on any explicit --expected-* mismatch.
+```
+
+A failing `--expected-*` check forces the process to exit non-zero, so a
+CI gate using these flags fails closed on a wrong workload.
+
 ## Documentation
 
 - Core library: `crates/attestation/README.md`

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ use attestation::types::VerifyParams;
 let params = VerifyParams {
     // TDX policy
     expected_mrtd: Some(mrtd_bytes),                   // [u8; 48]
-    expected_rtmrs: Some([None, Some(rtmr1), Some(rtmr2), None]),
+    expected_rtmr1: Some(rtmr1_bytes),
+    expected_rtmr2: Some(rtmr2_bytes),
     // SNP policy
     expected_launch_digest: Some(launch_digest_bytes), // [u8; 48]
     // existing fields
@@ -121,13 +122,14 @@ let params = VerifyParams {
 
 let result = attestation::verify(&evidence_json, &params).await?;
 assert_eq!(result.mrtd_match, Some(true));
-assert_eq!(result.rtmr_matches, Some([None, Some(true), Some(true), None]));
+assert_eq!(result.rtmr1_match, Some(true));
+assert_eq!(result.rtmr2_match, Some(true));
 ```
 
 All comparisons are constant-time (`subtle::ConstantTimeEq`) and do not
-short-circuit between RTMRs — every populated reference is checked.
-`VerificationResult` carries `#[must_use]` so dropping the result without
-inspecting the policy outcomes is a compile-time warning.
+short-circuit — every populated reference is checked. `VerificationResult`
+carries `#[must_use]` so dropping the result without inspecting the policy
+outcomes is a compile-time warning.
 
 The CLI exposes matching flags:
 

--- a/crates/attestation-api/src/api/verify.rs
+++ b/crates/attestation-api/src/api/verify.rs
@@ -79,6 +79,16 @@ pub async fn handler(
         ));
     }
 
+    // DEVIATION: VerifyParams gained `expected_mrtd`, `expected_rtmrs`,
+    // and `expected_launch_digest` for launch-measurement pinning, but
+    // the HTTP API does not surface them yet. Adding them needs a
+    // matching request DTO change, JSON encoding for the per-RTMR Option
+    // array, and a per-endpoint policy story about whether the server
+    // owns the reference values (e.g. fetched from a manifest registry)
+    // or the client supplies them. Until that design is settled the
+    // safe default is "no comparison" — the response's `mrtd_match` etc.
+    // will be `None`, which is correct (no check requested). The CLI is
+    // the only consumer of the new policy fields in this PR.
     let params = attestation::VerifyParams {
         expected_report_data,
         expected_init_data_hash,

--- a/crates/attestation-api/src/api/verify.rs
+++ b/crates/attestation-api/src/api/verify.rs
@@ -84,6 +84,7 @@ pub async fn handler(
         expected_init_data_hash,
         allow_debug,
         min_tcb,
+        ..Default::default()
     };
 
     let result = state.verifier.verify(&evidence_json, &params).await?;

--- a/crates/attestation-api/src/api/verify.rs
+++ b/crates/attestation-api/src/api/verify.rs
@@ -79,16 +79,6 @@ pub async fn handler(
         ));
     }
 
-    // DEVIATION: VerifyParams gained `expected_mrtd`, `expected_rtmrs`,
-    // and `expected_launch_digest` for launch-measurement pinning, but
-    // the HTTP API does not surface them yet. Adding them needs a
-    // matching request DTO change, JSON encoding for the per-RTMR Option
-    // array, and a per-endpoint policy story about whether the server
-    // owns the reference values (e.g. fetched from a manifest registry)
-    // or the client supplies them. Until that design is settled the
-    // safe default is "no comparison" — the response's `mrtd_match` etc.
-    // will be `None`, which is correct (no check requested). The CLI is
-    // the only consumer of the new policy fields in this PR.
     let params = attestation::VerifyParams {
         expected_report_data,
         expected_init_data_hash,

--- a/crates/attestation-api/tests/cert_tests.rs
+++ b/crates/attestation-api/tests/cert_tests.rs
@@ -78,7 +78,10 @@ fn token_issuer_produces_valid_jwt() {
         collateral_verified: false,
         tcb_status: None,
         mrtd_match: None,
-        rtmr_matches: None,
+        rtmr0_match: None,
+        rtmr1_match: None,
+        rtmr2_match: None,
+        rtmr3_match: None,
         launch_digest_match: None,
     };
 

--- a/crates/attestation-api/tests/cert_tests.rs
+++ b/crates/attestation-api/tests/cert_tests.rs
@@ -77,6 +77,9 @@ fn token_issuer_produces_valid_jwt() {
         init_data_match: None,
         collateral_verified: false,
         tcb_status: None,
+        mrtd_match: None,
+        rtmr_matches: None,
+        launch_digest_match: None,
     };
 
     let token = issuer.issue(&result).unwrap();

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -79,6 +79,30 @@ struct VerifyArgs {
     /// Expected init data hash (hex-encoded) for init data binding verification.
     #[arg(long)]
     expected_init_data: Option<String>,
+
+    /// Expected MRTD (hex-encoded, 48 bytes). TDX-only.
+    #[arg(long)]
+    expected_mrtd: Option<String>,
+
+    /// Expected RTMR[0] (hex-encoded, 48 bytes). TDX-only.
+    #[arg(long)]
+    expected_rtmr0: Option<String>,
+
+    /// Expected RTMR[1] (hex-encoded, 48 bytes). TDX-only.
+    #[arg(long)]
+    expected_rtmr1: Option<String>,
+
+    /// Expected RTMR[2] (hex-encoded, 48 bytes). TDX-only.
+    #[arg(long)]
+    expected_rtmr2: Option<String>,
+
+    /// Expected RTMR[3] (hex-encoded, 48 bytes). TDX-only.
+    #[arg(long)]
+    expected_rtmr3: Option<String>,
+
+    /// Expected SNP launch digest (hex-encoded, 48 bytes). SNP-only.
+    #[arg(long)]
+    expected_launch_digest: Option<String>,
 }
 
 #[cfg(all(feature = "attest", target_os = "linux"))]
@@ -277,6 +301,53 @@ async fn cmd_verify(args: VerifyArgs) {
                 process::exit(1);
             }
         }
+    }
+
+    let parse_digest = |hex_str: &str, name: &str| -> [u8; 48] {
+        let bytes = match hex::decode(hex_str) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("Error: invalid hex for --{name}: {e}");
+                process::exit(1);
+            }
+        };
+        match <[u8; 48]>::try_from(bytes.as_slice()) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!(
+                    "Error: --{name} must be 48 bytes (96 hex chars), got {} bytes",
+                    bytes.len()
+                );
+                process::exit(1);
+            }
+        }
+    };
+
+    if let Some(ref hex_str) = args.expected_mrtd {
+        params.expected_mrtd = Some(parse_digest(hex_str, "expected-mrtd"));
+    }
+    if let Some(ref hex_str) = args.expected_launch_digest {
+        params.expected_launch_digest = Some(parse_digest(hex_str, "expected-launch-digest"));
+    }
+    let any_rtmr = args.expected_rtmr0.is_some()
+        || args.expected_rtmr1.is_some()
+        || args.expected_rtmr2.is_some()
+        || args.expected_rtmr3.is_some();
+    if any_rtmr {
+        let mut rtmrs: [Option<[u8; 48]>; 4] = [None, None, None, None];
+        if let Some(ref h) = args.expected_rtmr0 {
+            rtmrs[0] = Some(parse_digest(h, "expected-rtmr0"));
+        }
+        if let Some(ref h) = args.expected_rtmr1 {
+            rtmrs[1] = Some(parse_digest(h, "expected-rtmr1"));
+        }
+        if let Some(ref h) = args.expected_rtmr2 {
+            rtmrs[2] = Some(parse_digest(h, "expected-rtmr2"));
+        }
+        if let Some(ref h) = args.expected_rtmr3 {
+            rtmrs[3] = Some(parse_digest(h, "expected-rtmr3"));
+        }
+        params.expected_rtmrs = Some(rtmrs);
     }
 
     eprintln!("Verifying evidence...");

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -391,13 +391,8 @@ async fn cmd_verify(args: VerifyArgs) {
     let json = serde_json::to_string_pretty(&result).expect("failed to serialize result");
     println!("{json}");
 
-    // Exit non-zero on ANY failure that was actually checked. The new
-    // `expected_*` fields produce `Some(false)` only when the operator
-    // explicitly asked for the check, so this is exactly the "I pinned a
-    // reference and the live measurement does not match" case — which is
-    // the entire point of the policy. Without this, `--expected-mrtd
-    // $WRONG` would still exit 0 and any CI/deployment gate that relied
-    // on the exit code would silently green-light an attacker workload.
+    // Exit non-zero on signature failure or any explicit policy mismatch
+    // so CI/deploy gates fail closed when a pinned reference drifts.
     let policy_failed = matches!(result.report_data_match, Some(false))
         || matches!(result.init_data_match, Some(false))
         || matches!(result.mrtd_match, Some(false))

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -132,11 +132,11 @@ impl PlatformArg {
 
 #[cfg(all(feature = "attest", target_os = "linux"))]
 fn resolve_report_data(group: &ReportDataGroup) -> Result<Vec<u8>, String> {
-    if let Some(ref s) = group.report_data {
+    if let Some(s) = &group.report_data {
         Ok(s.as_bytes().to_vec())
-    } else if let Some(ref h) = group.report_data_hex {
+    } else if let Some(h) = &group.report_data_hex {
         hex::decode(h).map_err(|e| format!("invalid hex for --report-data-hex: {e}"))
-    } else if let Some(ref path) = group.report_data_file {
+    } else if let Some(path) = &group.report_data_file {
         std::fs::read(path).map_err(|e| format!("failed to read {}: {e}", path.display()))
     } else {
         Ok(Vec::new())
@@ -146,7 +146,7 @@ fn resolve_report_data(group: &ReportDataGroup) -> Result<Vec<u8>, String> {
 fn read_evidence(args: &VerifyArgs) -> Result<Vec<u8>, String> {
     let max_size = attestation::MAX_EVIDENCE_SIZE;
 
-    if let Some(ref path) = args.evidence {
+    if let Some(path) = &args.evidence {
         let meta = std::fs::metadata(path)
             .map_err(|e| format!("failed to stat {}: {e}", path.display()))?;
         if meta.len() > max_size as u64 {
@@ -210,7 +210,7 @@ async fn cmd_attest(args: AttestArgs) {
         }
     };
 
-    let platform = if let Some(ref p) = args.platform {
+    let platform = if let Some(p) = &args.platform {
         p.to_platform_type()
     } else {
         match attestation::detect() {
@@ -251,7 +251,7 @@ async fn cmd_attest(args: AttestArgs) {
         evidence_json.len()
     );
 
-    if let Some(ref path) = args.output {
+    if let Some(path) = &args.output {
         if let Err(e) = std::fs::write(path, &evidence_json) {
             eprintln!("Failed to write {}: {e}", path.display());
             process::exit(1);
@@ -283,7 +283,7 @@ async fn cmd_verify(args: VerifyArgs) {
 
     let mut params = VerifyParams::default();
 
-    if let Some(ref hex_str) = args.expected_report_data {
+    if let Some(hex_str) = &args.expected_report_data {
         match hex::decode(hex_str) {
             Ok(data) => params.expected_report_data = Some(data),
             Err(e) => {
@@ -293,7 +293,7 @@ async fn cmd_verify(args: VerifyArgs) {
         }
     }
 
-    if let Some(ref hex_str) = args.expected_init_data {
+    if let Some(hex_str) = &args.expected_init_data {
         match hex::decode(hex_str) {
             Ok(data) => params.expected_init_data_hash = Some(data),
             Err(e) => {
@@ -323,22 +323,22 @@ async fn cmd_verify(args: VerifyArgs) {
         }
     };
 
-    if let Some(ref hex_str) = args.expected_mrtd {
+    if let Some(hex_str) = &args.expected_mrtd {
         params.expected_mrtd = Some(parse_digest(hex_str, "expected-mrtd"));
     }
-    if let Some(ref hex_str) = args.expected_launch_digest {
+    if let Some(hex_str) = &args.expected_launch_digest {
         params.expected_launch_digest = Some(parse_digest(hex_str, "expected-launch-digest"));
     }
-    if let Some(ref h) = args.expected_rtmr0 {
+    if let Some(h) = &args.expected_rtmr0 {
         params.expected_rtmr0 = Some(parse_digest(h, "expected-rtmr0"));
     }
-    if let Some(ref h) = args.expected_rtmr1 {
+    if let Some(h) = &args.expected_rtmr1 {
         params.expected_rtmr1 = Some(parse_digest(h, "expected-rtmr1"));
     }
-    if let Some(ref h) = args.expected_rtmr2 {
+    if let Some(h) = &args.expected_rtmr2 {
         params.expected_rtmr2 = Some(parse_digest(h, "expected-rtmr2"));
     }
-    if let Some(ref h) = args.expected_rtmr3 {
+    if let Some(h) = &args.expected_rtmr3 {
         params.expected_rtmr3 = Some(parse_digest(h, "expected-rtmr3"));
     }
 

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -329,25 +329,17 @@ async fn cmd_verify(args: VerifyArgs) {
     if let Some(ref hex_str) = args.expected_launch_digest {
         params.expected_launch_digest = Some(parse_digest(hex_str, "expected-launch-digest"));
     }
-    let any_rtmr = args.expected_rtmr0.is_some()
-        || args.expected_rtmr1.is_some()
-        || args.expected_rtmr2.is_some()
-        || args.expected_rtmr3.is_some();
-    if any_rtmr {
-        let mut rtmrs: [Option<[u8; 48]>; 4] = [None, None, None, None];
-        if let Some(ref h) = args.expected_rtmr0 {
-            rtmrs[0] = Some(parse_digest(h, "expected-rtmr0"));
-        }
-        if let Some(ref h) = args.expected_rtmr1 {
-            rtmrs[1] = Some(parse_digest(h, "expected-rtmr1"));
-        }
-        if let Some(ref h) = args.expected_rtmr2 {
-            rtmrs[2] = Some(parse_digest(h, "expected-rtmr2"));
-        }
-        if let Some(ref h) = args.expected_rtmr3 {
-            rtmrs[3] = Some(parse_digest(h, "expected-rtmr3"));
-        }
-        params.expected_rtmrs = Some(rtmrs);
+    if let Some(ref h) = args.expected_rtmr0 {
+        params.expected_rtmr0 = Some(parse_digest(h, "expected-rtmr0"));
+    }
+    if let Some(ref h) = args.expected_rtmr1 {
+        params.expected_rtmr1 = Some(parse_digest(h, "expected-rtmr1"));
+    }
+    if let Some(ref h) = args.expected_rtmr2 {
+        params.expected_rtmr2 = Some(parse_digest(h, "expected-rtmr2"));
+    }
+    if let Some(ref h) = args.expected_rtmr3 {
+        params.expected_rtmr3 = Some(parse_digest(h, "expected-rtmr3"));
     }
 
     eprintln!("Verifying evidence...");
@@ -379,11 +371,17 @@ async fn cmd_verify(args: VerifyArgs) {
     if let Some(m) = result.launch_digest_match {
         eprintln!("  Launch digest match: {m}");
     }
-    if let Some(matches) = result.rtmr_matches {
-        for (i, m) in matches.iter().enumerate() {
-            if let Some(b) = m {
-                eprintln!("  RTMR[{i}] match: {b}");
-            }
+    for (i, m) in [
+        result.rtmr0_match,
+        result.rtmr1_match,
+        result.rtmr2_match,
+        result.rtmr3_match,
+    ]
+    .iter()
+    .enumerate()
+    {
+        if let Some(b) = m {
+            eprintln!("  RTMR[{i}] match: {b}");
         }
     }
 
@@ -397,10 +395,10 @@ async fn cmd_verify(args: VerifyArgs) {
         || matches!(result.init_data_match, Some(false))
         || matches!(result.mrtd_match, Some(false))
         || matches!(result.launch_digest_match, Some(false))
-        || result
-            .rtmr_matches
-            .as_ref()
-            .is_some_and(|m| m.iter().any(|x| matches!(x, Some(false))));
+        || matches!(result.rtmr0_match, Some(false))
+        || matches!(result.rtmr1_match, Some(false))
+        || matches!(result.rtmr2_match, Some(false))
+        || matches!(result.rtmr3_match, Some(false));
     if !result.signature_valid || policy_failed {
         process::exit(1);
     }

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -373,12 +373,40 @@ async fn cmd_verify(args: VerifyArgs) {
     if let Some(m) = result.init_data_match {
         eprintln!("  Init data match: {m}");
     }
+    if let Some(m) = result.mrtd_match {
+        eprintln!("  MRTD match: {m}");
+    }
+    if let Some(m) = result.launch_digest_match {
+        eprintln!("  Launch digest match: {m}");
+    }
+    if let Some(matches) = result.rtmr_matches {
+        for (i, m) in matches.iter().enumerate() {
+            if let Some(b) = m {
+                eprintln!("  RTMR[{i}] match: {b}");
+            }
+        }
+    }
 
     // Structured JSON to stdout
     let json = serde_json::to_string_pretty(&result).expect("failed to serialize result");
     println!("{json}");
 
-    if !result.signature_valid {
+    // Exit non-zero on ANY failure that was actually checked. The new
+    // `expected_*` fields produce `Some(false)` only when the operator
+    // explicitly asked for the check, so this is exactly the "I pinned a
+    // reference and the live measurement does not match" case — which is
+    // the entire point of the policy. Without this, `--expected-mrtd
+    // $WRONG` would still exit 0 and any CI/deployment gate that relied
+    // on the exit code would silently green-light an attacker workload.
+    let policy_failed = matches!(result.report_data_match, Some(false))
+        || matches!(result.init_data_match, Some(false))
+        || matches!(result.mrtd_match, Some(false))
+        || matches!(result.launch_digest_match, Some(false))
+        || result
+            .rtmr_matches
+            .as_ref()
+            .is_some_and(|m| m.iter().any(|x| matches!(x, Some(false))));
+    if !result.signature_valid || policy_failed {
         process::exit(1);
     }
 }

--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -208,8 +208,16 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
     // Init data and result
     let init_data_match =
         tpm_common::check_init_data(&tpm_pcrs, params.expected_init_data_hash.as_deref())?;
+
+    // Optional launch-measurement comparison against a pre-computed reference.
+    // Mismatch does NOT fail verification — surfaced via the result field for
+    // the caller's policy layer.
+    let launch_digest_match = params.expected_launch_digest.as_ref().map(|expected| {
+        crate::utils::constant_time_eq(&snp_report.measurement[..], expected)
+    });
+
     let snp_claims = crate::platforms::snp::claims::extract_claims(&snp_report);
-    let result = tpm_common::build_tpm_verification_result(
+    let mut result = tpm_common::build_tpm_verification_result(
         snp_claims,
         &tpm_pcrs,
         &tpm_msg,
@@ -220,6 +228,7 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
         // the synchronous core has not checked revocation.
         false,
     );
+    result.launch_digest_match = launch_digest_match;
     Ok(VerifiedReport {
         result,
         matched_gen,

--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -209,12 +209,12 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
     let init_data_match =
         tpm_common::check_init_data(&tpm_pcrs, params.expected_init_data_hash.as_deref())?;
 
-    // Optional launch-measurement comparison against a pre-computed reference.
-    // Mismatch does NOT fail verification — surfaced via the result field for
-    // the caller's policy layer.
-    let launch_digest_match = params.expected_launch_digest.as_ref().map(|expected| {
-        crate::utils::constant_time_eq(&snp_report.measurement[..], expected)
-    });
+    // Optional launch-digest compare. Mismatch surfaces in the result and
+    // does not fail verification.
+    let launch_digest_match = params
+        .expected_launch_digest
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&snp_report.measurement[..], expected));
 
     let snp_claims = crate::platforms::snp::claims::extract_claims(&snp_report);
     let mut result = tpm_common::build_tpm_verification_result(

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -131,21 +131,22 @@ pub async fn verify_evidence(
         .expected_mrtd
         .as_ref()
         .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.mr_td, expected));
-    let rtmr_matches = params.expected_rtmrs.as_ref().map(|expected| {
-        let rtmrs = [
-            &tdx_quote.body.rtmr_0,
-            &tdx_quote.body.rtmr_1,
-            &tdx_quote.body.rtmr_2,
-            &tdx_quote.body.rtmr_3,
-        ];
-        let mut out: [Option<bool>; 4] = [None, None, None, None];
-        for (i, slot) in expected.iter().enumerate() {
-            if let Some(exp) = slot {
-                out[i] = Some(crate::utils::constant_time_eq(rtmrs[i], exp));
-            }
-        }
-        out
-    });
+    let rtmr0_match = params
+        .expected_rtmr0
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_0, expected));
+    let rtmr1_match = params
+        .expected_rtmr1
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_1, expected));
+    let rtmr2_match = params
+        .expected_rtmr2
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_2, expected));
+    let rtmr3_match = params
+        .expected_rtmr3
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_3, expected));
 
     // Result
     let tdx_claims = extract_claims(&tdx_quote);
@@ -161,7 +162,10 @@ pub async fn verify_evidence(
     );
     result.tcb_status = tcb_status;
     result.mrtd_match = mrtd_match;
-    result.rtmr_matches = rtmr_matches;
+    result.rtmr0_match = rtmr0_match;
+    result.rtmr1_match = rtmr1_match;
+    result.rtmr2_match = rtmr2_match;
+    result.rtmr3_match = rtmr3_match;
     Ok(result)
 }
 

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -125,6 +125,28 @@ pub async fn verify_evidence(
     let init_data_match =
         tpm_common::check_init_data(&tpm_pcrs, params.expected_init_data_hash.as_deref())?;
 
+    // Optional launch-measurement (MRTD / RTMR) comparisons against the inner
+    // TDX quote. Mismatches do NOT fail verification — surfaced via the
+    // result fields for the caller's policy layer.
+    let mrtd_match = params.expected_mrtd.as_ref().map(|expected| {
+        crate::utils::constant_time_eq(&tdx_quote.body.mr_td, expected)
+    });
+    let rtmr_matches = params.expected_rtmrs.as_ref().map(|expected| {
+        let rtmrs = [
+            &tdx_quote.body.rtmr_0,
+            &tdx_quote.body.rtmr_1,
+            &tdx_quote.body.rtmr_2,
+            &tdx_quote.body.rtmr_3,
+        ];
+        let mut out: [Option<bool>; 4] = [None, None, None, None];
+        for (i, slot) in expected.iter().enumerate() {
+            if let Some(exp) = slot {
+                out[i] = Some(crate::utils::constant_time_eq(rtmrs[i], exp));
+            }
+        }
+        out
+    });
+
     // Result
     let tdx_claims = extract_claims(&tdx_quote);
     let collateral_verified = tcb_status.is_some();
@@ -138,6 +160,8 @@ pub async fn verify_evidence(
         collateral_verified,
     );
     result.tcb_status = tcb_status;
+    result.mrtd_match = mrtd_match;
+    result.rtmr_matches = rtmr_matches;
     Ok(result)
 }
 

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -125,12 +125,12 @@ pub async fn verify_evidence(
     let init_data_match =
         tpm_common::check_init_data(&tpm_pcrs, params.expected_init_data_hash.as_deref())?;
 
-    // Optional launch-measurement (MRTD / RTMR) comparisons against the inner
-    // TDX quote. Mismatches do NOT fail verification — surfaced via the
-    // result fields for the caller's policy layer.
-    let mrtd_match = params.expected_mrtd.as_ref().map(|expected| {
-        crate::utils::constant_time_eq(&tdx_quote.body.mr_td, expected)
-    });
+    // Optional MRTD / RTMR compares. Mismatches surface in the result and
+    // do not fail verification.
+    let mrtd_match = params
+        .expected_mrtd
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.mr_td, expected));
     let rtmr_matches = params.expected_rtmrs.as_ref().map(|expected| {
         let rtmrs = [
             &tdx_quote.body.rtmr_0,

--- a/crates/attestation/src/platforms/gcp_snp/verify.rs
+++ b/crates/attestation/src/platforms/gcp_snp/verify.rs
@@ -49,15 +49,13 @@ pub async fn verify_evidence(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use crate::error::AttestationError;
     use crate::platforms::snp::evidence::SnpCertChain;
     use crate::platforms::snp::verify::parse_report;
     use crate::types::{ProcessorGeneration, SnpTcb};
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 
-    // Same live Genoa v5 fixture used by the bare-metal SNP tests.
-    const LIVE_REPORT_V5: &[u8] =
-        include_bytes!("../../../test_data/snp/live-report-v5-genoa.bin");
+    const LIVE_REPORT_V5: &[u8] = include_bytes!("../../../test_data/snp/live-report-v5-genoa.bin");
     const LIVE_VCEK_GENOA: &[u8] = include_bytes!("../../../test_data/snp/live-vcek-genoa.der");
 
     /// Cert provider that returns the bundled live Genoa VCEK. No network,
@@ -107,7 +105,9 @@ mod tests {
             expected_launch_digest: Some(expected),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, &StubCertProvider).await.unwrap();
+        let r = verify_evidence(&evidence, &params, &StubCertProvider)
+            .await
+            .unwrap();
         assert_eq!(r.platform, PlatformType::GcpSnp);
         assert_eq!(r.launch_digest_match, Some(true));
     }
@@ -119,7 +119,9 @@ mod tests {
             expected_launch_digest: Some([0x77; 48]),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, &StubCertProvider).await.unwrap();
+        let r = verify_evidence(&evidence, &params, &StubCertProvider)
+            .await
+            .unwrap();
         assert_eq!(r.platform, PlatformType::GcpSnp);
         assert_eq!(r.launch_digest_match, Some(false));
         // Even with wrong digest, signature still valid — policy decision in caller

--- a/crates/attestation/src/platforms/gcp_snp/verify.rs
+++ b/crates/attestation/src/platforms/gcp_snp/verify.rs
@@ -45,3 +45,84 @@ pub async fn verify_evidence(
     result.platform = PlatformType::GcpSnp;
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+    use crate::error::AttestationError;
+    use crate::platforms::snp::evidence::SnpCertChain;
+    use crate::platforms::snp::verify::parse_report;
+    use crate::types::{ProcessorGeneration, SnpTcb};
+
+    // Same live Genoa v5 fixture used by the bare-metal SNP tests.
+    const LIVE_REPORT_V5: &[u8] =
+        include_bytes!("../../../test_data/snp/live-report-v5-genoa.bin");
+    const LIVE_VCEK_GENOA: &[u8] = include_bytes!("../../../test_data/snp/live-vcek-genoa.der");
+
+    /// Cert provider that returns the bundled live Genoa VCEK. No network,
+    /// no CRL (so collateral_verified=false).
+    struct StubCertProvider;
+
+    #[async_trait::async_trait]
+    impl crate::collateral::CertProvider for StubCertProvider {
+        async fn get_snp_vcek(
+            &self,
+            _processor_gen: ProcessorGeneration,
+            _chip_id: &[u8; 64],
+            _reported_tcb: &SnpTcb,
+        ) -> crate::error::Result<Vec<u8>> {
+            Ok(LIVE_VCEK_GENOA.to_vec())
+        }
+
+        async fn get_snp_cert_chain(
+            &self,
+            _processor_gen: ProcessorGeneration,
+        ) -> crate::error::Result<(Vec<u8>, Vec<u8>)> {
+            Err(AttestationError::CertFetchError(
+                "stub provider does not serve full chain".to_string(),
+            ))
+        }
+    }
+
+    fn make_snp_evidence(report: &[u8], vcek_der: &[u8]) -> SnpEvidence {
+        SnpEvidence {
+            attestation_report: BASE64.encode(report),
+            cert_chain: Some(SnpCertChain {
+                vcek: BASE64.encode(vcek_der),
+                ask: None,
+                ark: None,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gcp_snp_propagates_matching_launch_digest() {
+        let report = parse_report(LIVE_REPORT_V5).unwrap();
+        let mut expected = [0u8; 48];
+        expected.copy_from_slice(&report.measurement[..]);
+
+        let evidence = make_snp_evidence(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
+        let params = VerifyParams {
+            expected_launch_digest: Some(expected),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, &StubCertProvider).await.unwrap();
+        assert_eq!(r.platform, PlatformType::GcpSnp);
+        assert_eq!(r.launch_digest_match, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_gcp_snp_propagates_wrong_launch_digest() {
+        let evidence = make_snp_evidence(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
+        let params = VerifyParams {
+            expected_launch_digest: Some([0x77; 48]),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, &StubCertProvider).await.unwrap();
+        assert_eq!(r.platform, PlatformType::GcpSnp);
+        assert_eq!(r.launch_digest_match, Some(false));
+        // Even with wrong digest, signature still valid — policy decision in caller
+        assert!(r.signature_valid);
+    }
+}

--- a/crates/attestation/src/platforms/gcp_tdx/verify.rs
+++ b/crates/attestation/src/platforms/gcp_tdx/verify.rs
@@ -47,3 +47,49 @@ pub async fn verify_evidence(
     result.platform = PlatformType::GcpTdx;
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+    use crate::platforms::tdx::verify::parse_tdx_quote;
+
+    // Same v4 fixture the bare-metal TDX tests use — proves the GCP overlay
+    // simply forwards expected_mrtd/expected_rtmrs to the underlying TDX
+    // pipeline.
+    const V4_QUOTE: &[u8] = include_bytes!("../../../test_data/tdx_quote_4.dat");
+
+    fn make_tdx_evidence(quote_bytes: &[u8]) -> TdxEvidence {
+        TdxEvidence {
+            quote: BASE64.encode(quote_bytes),
+            cc_eventlog: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gcp_tdx_propagates_expected_mrtd_match() {
+        let quote = parse_tdx_quote(V4_QUOTE).unwrap();
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let params = VerifyParams {
+            allow_debug: true, // v4 fixture has the debug bit set
+            expected_mrtd: Some(quote.body.mr_td),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        assert_eq!(r.platform, PlatformType::GcpTdx);
+        assert_eq!(r.mrtd_match, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_gcp_tdx_propagates_wrong_mrtd_match() {
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let params = VerifyParams {
+            allow_debug: true,
+            expected_mrtd: Some([0x55; 48]),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        assert_eq!(r.platform, PlatformType::GcpTdx);
+        assert_eq!(r.mrtd_match, Some(false));
+    }
+}

--- a/crates/attestation/src/platforms/gcp_tdx/verify.rs
+++ b/crates/attestation/src/platforms/gcp_tdx/verify.rs
@@ -51,12 +51,9 @@ pub async fn verify_evidence(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use crate::platforms::tdx::verify::parse_tdx_quote;
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 
-    // Same v4 fixture the bare-metal TDX tests use — proves the GCP overlay
-    // simply forwards expected_mrtd/expected_rtmrs to the underlying TDX
-    // pipeline.
     const V4_QUOTE: &[u8] = include_bytes!("../../../test_data/tdx_quote_4.dat");
 
     fn make_tdx_evidence(quote_bytes: &[u8]) -> TdxEvidence {

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -176,7 +176,10 @@ pub async fn verify_evidence(
         collateral_verified: crl_verified,
         tcb_status: None,
         mrtd_match: None,
-        rtmr_matches: None,
+        rtmr0_match: None,
+        rtmr1_match: None,
+        rtmr2_match: None,
+        rtmr3_match: None,
         launch_digest_match,
     })
 }
@@ -1029,7 +1032,10 @@ mod tests {
             .expect("live v5 fixture should verify");
         assert!(r.launch_digest_match.is_none(), "no expected_* → None");
         assert!(r.mrtd_match.is_none(), "SNP never sets mrtd_match");
-        assert!(r.rtmr_matches.is_none(), "SNP never sets rtmr_matches");
+        assert!(r.rtmr0_match.is_none(), "SNP never sets rtmrN_match");
+        assert!(r.rtmr1_match.is_none());
+        assert!(r.rtmr2_match.is_none());
+        assert!(r.rtmr3_match.is_none());
     }
 
     #[tokio::test]

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -157,6 +157,13 @@ pub async fn verify_evidence(
         None
     };
 
+    // 10b. Optional launch measurement comparison against a pre-computed
+    // reference. Mismatches do NOT fail verification — the result field
+    // is surfaced to the caller, who decides whether to reject.
+    let launch_digest_match = params.expected_launch_digest.as_ref().map(|expected| {
+        crate::utils::constant_time_eq(&report.measurement[..], expected)
+    });
+
     // 11. Extract claims
     let claims = extract_claims(&report);
 
@@ -168,6 +175,9 @@ pub async fn verify_evidence(
         init_data_match,
         collateral_verified: crl_verified,
         tcb_status: None,
+        mrtd_match: None,
+        rtmr_matches: None,
+        launch_digest_match,
     })
 }
 

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -157,12 +157,12 @@ pub async fn verify_evidence(
         None
     };
 
-    // 10b. Optional launch measurement comparison against a pre-computed
-    // reference. Mismatches do NOT fail verification — the result field
-    // is surfaced to the caller, who decides whether to reject.
-    let launch_digest_match = params.expected_launch_digest.as_ref().map(|expected| {
-        crate::utils::constant_time_eq(&report.measurement[..], expected)
-    });
+    // Optional launch-digest compare. Mismatch surfaces in the result and
+    // does not fail verification.
+    let launch_digest_match = params
+        .expected_launch_digest
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&report.measurement[..], expected));
 
     // 11. Extract claims
     let claims = extract_claims(&report);
@@ -980,15 +980,7 @@ mod tests {
         );
     }
 
-    // ---------------------------------------------------------------
-    // expected_launch_digest tests — closes the policy gap where the
-    // verifier can prove "this report is valid" but cannot prove
-    // "this report represents OUR published build."
-    //
-    // Uses the LIVE_REPORT_V5 (Genoa v5, VMPL=0) fixture together
-    // with LIVE_VCEK_GENOA so the full verify_evidence pipeline
-    // (cert chain → report sig → VMPL → debug → VCEK TCB) all pass.
-    // ---------------------------------------------------------------
+    // expected_launch_digest tests against the live Genoa v5 fixture.
 
     /// Cert provider that returns the bundled live Genoa VCEK from the
     /// fixture. No network access, no CRL (so collateral_verified=false).
@@ -1052,21 +1044,24 @@ mod tests {
             expected_launch_digest: Some(expected),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, &provider).await.unwrap();
+        let r = verify_evidence(&evidence, &params, &provider)
+            .await
+            .unwrap();
         assert_eq!(r.launch_digest_match, Some(true));
     }
 
     #[tokio::test]
     async fn test_verify_evidence_wrong_launch_digest_is_some_false() {
-        // INVARIANT: wrong launch_digest records Some(false) but verification
-        // still succeeds — policy lives in the caller.
+        // Wrong digest must record Some(false) without failing verification.
         let evidence = make_snp_evidence_with_vcek(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
         let provider = StubCertProvider;
         let params = VerifyParams {
             expected_launch_digest: Some([0xAA; 48]),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, &provider).await.unwrap();
+        let r = verify_evidence(&evidence, &params, &provider)
+            .await
+            .unwrap();
         assert_eq!(r.launch_digest_match, Some(false));
         assert!(r.signature_valid, "wrong digest should NOT fail signature");
     }

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -979,4 +979,95 @@ mod tests {
             result.err()
         );
     }
+
+    // ---------------------------------------------------------------
+    // expected_launch_digest tests — closes the policy gap where the
+    // verifier can prove "this report is valid" but cannot prove
+    // "this report represents OUR published build."
+    //
+    // Uses the LIVE_REPORT_V5 (Genoa v5, VMPL=0) fixture together
+    // with LIVE_VCEK_GENOA so the full verify_evidence pipeline
+    // (cert chain → report sig → VMPL → debug → VCEK TCB) all pass.
+    // ---------------------------------------------------------------
+
+    /// Cert provider that returns the bundled live Genoa VCEK from the
+    /// fixture. No network access, no CRL (so collateral_verified=false).
+    struct StubCertProvider;
+
+    #[async_trait::async_trait]
+    impl crate::collateral::CertProvider for StubCertProvider {
+        async fn get_snp_vcek(
+            &self,
+            _processor_gen: ProcessorGeneration,
+            _chip_id: &[u8; 64],
+            _reported_tcb: &SnpTcb,
+        ) -> Result<Vec<u8>> {
+            Ok(LIVE_VCEK_GENOA.to_vec())
+        }
+
+        async fn get_snp_cert_chain(
+            &self,
+            _processor_gen: ProcessorGeneration,
+        ) -> Result<(Vec<u8>, Vec<u8>)> {
+            // Not used — the bare-metal SNP path uses bundled ARK/ASK directly.
+            Err(AttestationError::CertFetchError(
+                "stub provider does not serve full chain".to_string(),
+            ))
+        }
+    }
+
+    fn make_snp_evidence_with_vcek(report: &[u8], vcek_der: &[u8]) -> SnpEvidence {
+        use crate::platforms::snp::evidence::SnpCertChain;
+        SnpEvidence {
+            attestation_report: BASE64.encode(report),
+            cert_chain: Some(SnpCertChain {
+                vcek: BASE64.encode(vcek_der),
+                ask: None,
+                ark: None,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_no_expected_launch_digest_yields_none() {
+        let evidence = make_snp_evidence_with_vcek(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
+        let provider = StubCertProvider;
+        let r = verify_evidence(&evidence, &VerifyParams::default(), &provider)
+            .await
+            .expect("live v5 fixture should verify");
+        assert!(r.launch_digest_match.is_none(), "no expected_* → None");
+        assert!(r.mrtd_match.is_none(), "SNP never sets mrtd_match");
+        assert!(r.rtmr_matches.is_none(), "SNP never sets rtmr_matches");
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_matching_launch_digest() {
+        let report = parse_report(LIVE_REPORT_V5).unwrap();
+        let mut expected = [0u8; 48];
+        expected.copy_from_slice(&report.measurement[..]);
+
+        let evidence = make_snp_evidence_with_vcek(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
+        let provider = StubCertProvider;
+        let params = VerifyParams {
+            expected_launch_digest: Some(expected),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, &provider).await.unwrap();
+        assert_eq!(r.launch_digest_match, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_wrong_launch_digest_is_some_false() {
+        // INVARIANT: wrong launch_digest records Some(false) but verification
+        // still succeeds — policy lives in the caller.
+        let evidence = make_snp_evidence_with_vcek(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
+        let provider = StubCertProvider;
+        let params = VerifyParams {
+            expected_launch_digest: Some([0xAA; 48]),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, &provider).await.unwrap();
+        assert_eq!(r.launch_digest_match, Some(false));
+        assert!(r.signature_valid, "wrong digest should NOT fail signature");
+    }
 }

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -447,21 +447,22 @@ pub async fn verify_evidence(
         .expected_mrtd
         .as_ref()
         .map(|expected| crate::utils::constant_time_eq(&quote.body.mr_td, expected));
-    let rtmr_matches = params.expected_rtmrs.as_ref().map(|expected| {
-        let rtmrs = [
-            &quote.body.rtmr_0,
-            &quote.body.rtmr_1,
-            &quote.body.rtmr_2,
-            &quote.body.rtmr_3,
-        ];
-        let mut out: [Option<bool>; 4] = [None, None, None, None];
-        for (i, slot) in expected.iter().enumerate() {
-            if let Some(exp) = slot {
-                out[i] = Some(crate::utils::constant_time_eq(rtmrs[i], exp));
-            }
-        }
-        out
-    });
+    let rtmr0_match = params
+        .expected_rtmr0
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_0, expected));
+    let rtmr1_match = params
+        .expected_rtmr1
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_1, expected));
+    let rtmr2_match = params
+        .expected_rtmr2
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_2, expected));
+    let rtmr3_match = params
+        .expected_rtmr3
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_3, expected));
 
     // 6. Eventlog integrity check (if present)
     if let Some(ref eventlog_b64) = evidence.cc_eventlog {
@@ -490,7 +491,10 @@ pub async fn verify_evidence(
         collateral_verified: tcb_status.is_some(),
         tcb_status,
         mrtd_match,
-        rtmr_matches,
+        rtmr0_match,
+        rtmr1_match,
+        rtmr2_match,
+        rtmr3_match,
         launch_digest_match: None,
     })
 }
@@ -1020,7 +1024,10 @@ mod tests {
         };
         let r = verify_evidence(&evidence, &params, None).await.unwrap();
         assert!(r.mrtd_match.is_none(), "no expected_mrtd → None");
-        assert!(r.rtmr_matches.is_none(), "no expected_rtmrs → None");
+        assert!(r.rtmr0_match.is_none(), "no expected_rtmr0 → None");
+        assert!(r.rtmr1_match.is_none(), "no expected_rtmr1 → None");
+        assert!(r.rtmr2_match.is_none(), "no expected_rtmr2 → None");
+        assert!(r.rtmr3_match.is_none(), "no expected_rtmr3 → None");
         assert!(
             r.launch_digest_match.is_none(),
             "TDX never sets launch_digest_match"
@@ -1057,44 +1064,36 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_evidence_partial_rtmr_check() {
-        // Caller provides only rtmr0, leaving the others as inner None.
-        // rtmr_matches[0] should be Some(true); the rest remain None.
+        // Caller pins only rtmr0; the other rtmrN_match fields stay None.
         let quote = parse_tdx_quote(V4_QUOTE).unwrap();
         let evidence = make_tdx_evidence(V4_QUOTE);
-        let expected: [Option<[u8; 48]>; 4] = [Some(quote.body.rtmr_0), None, None, None];
         let params = VerifyParams {
             allow_debug: true,
-            expected_rtmrs: Some(expected),
+            expected_rtmr0: Some(quote.body.rtmr_0),
             ..Default::default()
         };
         let r = verify_evidence(&evidence, &params, None).await.unwrap();
-        let m = r.rtmr_matches.expect("rtmr_matches should be Some(...)");
-        assert_eq!(m[0], Some(true), "rtmr0 should match");
-        assert_eq!(m[1], None, "rtmr1 not requested → None");
-        assert_eq!(m[2], None, "rtmr2 not requested → None");
-        assert_eq!(m[3], None, "rtmr3 not requested → None");
+        assert_eq!(r.rtmr0_match, Some(true));
+        assert_eq!(r.rtmr1_match, None);
+        assert_eq!(r.rtmr2_match, None);
+        assert_eq!(r.rtmr3_match, None);
     }
 
     #[tokio::test]
     async fn test_verify_evidence_mixed_rtmr_match_and_mismatch() {
         let quote = parse_tdx_quote(V4_QUOTE).unwrap();
         let evidence = make_tdx_evidence(V4_QUOTE);
-        let expected: [Option<[u8; 48]>; 4] = [
-            Some(quote.body.rtmr_0), // match
-            Some([0xFF; 48]),        // mismatch
-            None,                    // skip
-            Some(quote.body.rtmr_3), // match
-        ];
         let params = VerifyParams {
             allow_debug: true,
-            expected_rtmrs: Some(expected),
+            expected_rtmr0: Some(quote.body.rtmr_0), // match
+            expected_rtmr1: Some([0xFF; 48]),        // mismatch
+            expected_rtmr3: Some(quote.body.rtmr_3), // match (rtmr2 left None → skipped)
             ..Default::default()
         };
         let r = verify_evidence(&evidence, &params, None).await.unwrap();
-        let m = r.rtmr_matches.unwrap();
-        assert_eq!(m[0], Some(true));
-        assert_eq!(m[1], Some(false));
-        assert_eq!(m[2], None);
-        assert_eq!(m[3], Some(true));
+        assert_eq!(r.rtmr0_match, Some(true));
+        assert_eq!(r.rtmr1_match, Some(false));
+        assert_eq!(r.rtmr2_match, None);
+        assert_eq!(r.rtmr3_match, Some(true));
     }
 }

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -1008,4 +1008,101 @@ mod tests {
         let result = verify_evidence(&evidence, &params, None).await;
         assert!(result.is_err(), "65-byte report_data should be rejected");
     }
+
+    // ---------------------------------------------------------------
+    // expected_mrtd / expected_rtmrs tests — closes the policy gap
+    // where the verifier can prove "this quote is valid" but cannot
+    // prove "this quote represents OUR published build."
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_verify_evidence_no_expected_measurements_yields_none() {
+        // Sanity: when the caller supplies no expected_* values, the result
+        // fields are None — distinguishing "skipped" from "failed".
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let params = VerifyParams {
+            allow_debug: true,
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        assert!(r.mrtd_match.is_none(), "no expected_mrtd → None");
+        assert!(r.rtmr_matches.is_none(), "no expected_rtmrs → None");
+        assert!(
+            r.launch_digest_match.is_none(),
+            "TDX never sets launch_digest_match"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_matching_mrtd() {
+        let quote = parse_tdx_quote(V4_QUOTE).unwrap();
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let params = VerifyParams {
+            allow_debug: true,
+            expected_mrtd: Some(quote.body.mr_td),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        assert_eq!(r.mrtd_match, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_wrong_mrtd_is_some_false() {
+        // INVARIANT: A wrong MRTD records Some(false) but DOES NOT fail the
+        // verifier. Policy lives in the caller — this test ensures we
+        // surface the mismatch rather than masking it as a hard error.
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let params = VerifyParams {
+            allow_debug: true,
+            expected_mrtd: Some([0xAA; 48]),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        assert_eq!(r.mrtd_match, Some(false));
+        // Crucially the rest of the result is still populated — sig is valid.
+        assert!(r.signature_valid);
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_partial_rtmr_check() {
+        // Caller provides only rtmr0, leaving the others as inner None.
+        // rtmr_matches[0] should be Some(true); the rest remain None.
+        let quote = parse_tdx_quote(V4_QUOTE).unwrap();
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let expected: [Option<[u8; 48]>; 4] = [Some(quote.body.rtmr_0), None, None, None];
+        let params = VerifyParams {
+            allow_debug: true,
+            expected_rtmrs: Some(expected),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        let m = r.rtmr_matches.expect("rtmr_matches should be Some(...)");
+        assert_eq!(m[0], Some(true), "rtmr0 should match");
+        assert_eq!(m[1], None, "rtmr1 not requested → None");
+        assert_eq!(m[2], None, "rtmr2 not requested → None");
+        assert_eq!(m[3], None, "rtmr3 not requested → None");
+    }
+
+    #[tokio::test]
+    async fn test_verify_evidence_mixed_rtmr_match_and_mismatch() {
+        let quote = parse_tdx_quote(V4_QUOTE).unwrap();
+        let evidence = make_tdx_evidence(V4_QUOTE);
+        let expected: [Option<[u8; 48]>; 4] = [
+            Some(quote.body.rtmr_0), // match
+            Some([0xFF; 48]),        // mismatch
+            None,                    // skip
+            Some(quote.body.rtmr_3), // match
+        ];
+        let params = VerifyParams {
+            allow_debug: true,
+            expected_rtmrs: Some(expected),
+            ..Default::default()
+        };
+        let r = verify_evidence(&evidence, &params, None).await.unwrap();
+        let m = r.rtmr_matches.unwrap();
+        assert_eq!(m[0], Some(true));
+        assert_eq!(m[1], Some(false));
+        assert_eq!(m[2], None);
+        assert_eq!(m[3], Some(true));
+    }
 }

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -441,6 +441,30 @@ pub async fn verify_evidence(
         None
     };
 
+    // 5b. Optional launch measurement (MRTD) and RTMR comparison against
+    // pre-computed reference values. Mismatches are surfaced via the
+    // result fields rather than failing verification — policy lives in
+    // the caller. Constant-time compares to avoid leaking which byte
+    // diverged for callers that route the digests over a network.
+    let mrtd_match = params.expected_mrtd.as_ref().map(|expected| {
+        crate::utils::constant_time_eq(&quote.body.mr_td, expected)
+    });
+    let rtmr_matches = params.expected_rtmrs.as_ref().map(|expected| {
+        let rtmrs = [
+            &quote.body.rtmr_0,
+            &quote.body.rtmr_1,
+            &quote.body.rtmr_2,
+            &quote.body.rtmr_3,
+        ];
+        let mut out: [Option<bool>; 4] = [None, None, None, None];
+        for (i, slot) in expected.iter().enumerate() {
+            if let Some(exp) = slot {
+                out[i] = Some(crate::utils::constant_time_eq(rtmrs[i], exp));
+            }
+        }
+        out
+    });
+
     // 6. Eventlog integrity check (if present)
     if let Some(ref eventlog_b64) = evidence.cc_eventlog {
         crate::utils::check_field_size("cc_eventlog", eventlog_b64.len())?;
@@ -467,6 +491,9 @@ pub async fn verify_evidence(
         init_data_match,
         collateral_verified: tcb_status.is_some(),
         tcb_status,
+        mrtd_match,
+        rtmr_matches,
+        launch_digest_match: None,
     })
 }
 

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -441,14 +441,12 @@ pub async fn verify_evidence(
         None
     };
 
-    // 5b. Optional launch measurement (MRTD) and RTMR comparison against
-    // pre-computed reference values. Mismatches are surfaced via the
-    // result fields rather than failing verification — policy lives in
-    // the caller. Constant-time compares to avoid leaking which byte
-    // diverged for callers that route the digests over a network.
-    let mrtd_match = params.expected_mrtd.as_ref().map(|expected| {
-        crate::utils::constant_time_eq(&quote.body.mr_td, expected)
-    });
+    // Optional MRTD / RTMR comparisons against caller-supplied references.
+    // Constant-time; mismatch surfaces in the result and does not fail verify.
+    let mrtd_match = params
+        .expected_mrtd
+        .as_ref()
+        .map(|expected| crate::utils::constant_time_eq(&quote.body.mr_td, expected));
     let rtmr_matches = params.expected_rtmrs.as_ref().map(|expected| {
         let rtmrs = [
             &quote.body.rtmr_0,
@@ -1009,11 +1007,7 @@ mod tests {
         assert!(result.is_err(), "65-byte report_data should be rejected");
     }
 
-    // ---------------------------------------------------------------
-    // expected_mrtd / expected_rtmrs tests — closes the policy gap
-    // where the verifier can prove "this quote is valid" but cannot
-    // prove "this quote represents OUR published build."
-    // ---------------------------------------------------------------
+    // expected_mrtd / expected_rtmrs tests
 
     #[tokio::test]
     async fn test_verify_evidence_no_expected_measurements_yields_none() {
@@ -1048,9 +1042,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_evidence_wrong_mrtd_is_some_false() {
-        // INVARIANT: A wrong MRTD records Some(false) but DOES NOT fail the
-        // verifier. Policy lives in the caller — this test ensures we
-        // surface the mismatch rather than masking it as a hard error.
+        // Wrong MRTD must record Some(false) without failing verification.
         let evidence = make_tdx_evidence(V4_QUOTE);
         let params = VerifyParams {
             allow_debug: true,

--- a/crates/attestation/src/platforms/tpm_common.rs
+++ b/crates/attestation/src/platforms/tpm_common.rs
@@ -721,6 +721,11 @@ pub fn build_tpm_verification_result(
         init_data_match,
         collateral_verified,
         tcb_status: None,
+        // Launch-measurement comparisons are platform-specific and populated
+        // by the caller (az_snp/az_tdx) after this generic TPM-result is built.
+        mrtd_match: None,
+        rtmr_matches: None,
+        launch_digest_match: None,
     }
 }
 

--- a/crates/attestation/src/platforms/tpm_common.rs
+++ b/crates/attestation/src/platforms/tpm_common.rs
@@ -721,10 +721,12 @@ pub fn build_tpm_verification_result(
         init_data_match,
         collateral_verified,
         tcb_status: None,
-        // Launch-measurement comparisons are platform-specific and populated
-        // by the caller (az_snp/az_tdx) after this generic TPM-result is built.
+        // Launch-measurement compares are populated by the caller (az_snp/az_tdx).
         mrtd_match: None,
-        rtmr_matches: None,
+        rtmr0_match: None,
+        rtmr1_match: None,
+        rtmr2_match: None,
+        rtmr3_match: None,
         launch_digest_match: None,
     }
 }

--- a/crates/attestation/src/types.rs
+++ b/crates/attestation/src/types.rs
@@ -74,6 +74,24 @@ pub struct VerifyParams {
     pub allow_debug: bool,
     /// If set, enforce minimum TCB version for SNP (each component must be >=).
     pub min_tcb: Option<SnpTcb>,
+    /// If set, verifier compares the TDX quote's MRTD (launch measurement)
+    /// against this expected 48-byte digest and records the result in
+    /// [`VerificationResult::mrtd_match`]. A mismatch does NOT fail the
+    /// signature/collateral path — callers inspect the bool to enforce policy.
+    /// Ignored for SNP platforms.
+    pub expected_mrtd: Option<[u8; 48]>,
+    /// If set, verifier compares each TDX RTMR (Runtime Measurement Register)
+    /// against the corresponding expected 48-byte digest. `None` entries are
+    /// skipped; comparison results land in [`VerificationResult::rtmr_matches`].
+    /// A mismatch does NOT fail verification — callers enforce policy.
+    /// Ignored for SNP platforms.
+    pub expected_rtmrs: Option<[Option<[u8; 48]>; 4]>,
+    /// If set, verifier compares the SNP attestation report's `measurement`
+    /// field (launch digest) against this expected 48-byte digest and records
+    /// the result in [`VerificationResult::launch_digest_match`]. A mismatch
+    /// does NOT fail verification — callers inspect the bool to enforce policy.
+    /// Ignored for TDX platforms.
+    pub expected_launch_digest: Option<[u8; 48]>,
 }
 
 /// Result of verification — the caller decides pass/fail based on this.
@@ -102,6 +120,25 @@ pub struct VerificationResult {
     /// Platform-specific collateral/TCB status details (TDX DCAP status, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tcb_status: Option<DcapVerificationStatus>,
+    /// Did the TDX MRTD (launch measurement) match the value supplied in
+    /// [`VerifyParams::expected_mrtd`]? `None` means no expected value was
+    /// provided. `Some(true)` / `Some(false)` reflect a constant-time compare.
+    /// Always `None` for SNP platforms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mrtd_match: Option<bool>,
+    /// Per-RTMR comparison results, matching the layout of
+    /// [`VerifyParams::expected_rtmrs`]. Inner `None` means no expected value
+    /// for that RTMR; `Some(bool)` is the constant-time-compare result.
+    /// The outer `None` means the caller provided no `expected_rtmrs` at all.
+    /// Always `None` for SNP platforms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtmr_matches: Option<[Option<bool>; 4]>,
+    /// Did the SNP launch digest (report.measurement) match the value supplied
+    /// in [`VerifyParams::expected_launch_digest`]? `None` means no expected
+    /// value was provided. `Some(bool)` reflects a constant-time compare.
+    /// Always `None` for TDX platforms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub launch_digest_match: Option<bool>,
 }
 
 /// Normalized claims extracted from evidence.

--- a/crates/attestation/src/types.rs
+++ b/crates/attestation/src/types.rs
@@ -95,7 +95,16 @@ pub struct VerifyParams {
 }
 
 /// Result of verification — the caller decides pass/fail based on this.
+///
+/// `#[must_use]`: this struct carries individual policy outcomes
+/// (`signature_valid`, `mrtd_match`, `rtmr_matches`, ...). Dropping it
+/// without inspecting those booleans means a caller asked
+/// `attestation::verify(...)` and then ignored whether the quote actually
+/// matched the policy. That is *always* a bug — the attribute makes the
+/// compiler warn at every call site that throws the result away. Add an
+/// explicit `let _ = result;` only if you genuinely don't care.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[must_use]
 pub struct VerificationResult {
     /// Was the hardware signature on the evidence valid?
     pub signature_valid: bool,

--- a/crates/attestation/src/types.rs
+++ b/crates/attestation/src/types.rs
@@ -74,35 +74,20 @@ pub struct VerifyParams {
     pub allow_debug: bool,
     /// If set, enforce minimum TCB version for SNP (each component must be >=).
     pub min_tcb: Option<SnpTcb>,
-    /// If set, verifier compares the TDX quote's MRTD (launch measurement)
-    /// against this expected 48-byte digest and records the result in
-    /// [`VerificationResult::mrtd_match`]. A mismatch does NOT fail the
-    /// signature/collateral path — callers inspect the bool to enforce policy.
-    /// Ignored for SNP platforms.
+    /// Expected MRTD. Result surfaces in [`VerificationResult::mrtd_match`];
+    /// mismatch does not fail verification. TDX-only.
     pub expected_mrtd: Option<[u8; 48]>,
-    /// If set, verifier compares each TDX RTMR (Runtime Measurement Register)
-    /// against the corresponding expected 48-byte digest. `None` entries are
-    /// skipped; comparison results land in [`VerificationResult::rtmr_matches`].
-    /// A mismatch does NOT fail verification — callers enforce policy.
-    /// Ignored for SNP platforms.
+    /// Expected RTMR[0..3] (inner `None` skips that RTMR). Results in
+    /// [`VerificationResult::rtmr_matches`]; mismatch does not fail
+    /// verification. TDX-only.
     pub expected_rtmrs: Option<[Option<[u8; 48]>; 4]>,
-    /// If set, verifier compares the SNP attestation report's `measurement`
-    /// field (launch digest) against this expected 48-byte digest and records
-    /// the result in [`VerificationResult::launch_digest_match`]. A mismatch
-    /// does NOT fail verification — callers inspect the bool to enforce policy.
-    /// Ignored for TDX platforms.
+    /// Expected SNP launch digest (`report.measurement`). Result in
+    /// [`VerificationResult::launch_digest_match`]; mismatch does not fail
+    /// verification. SNP-only.
     pub expected_launch_digest: Option<[u8; 48]>,
 }
 
 /// Result of verification — the caller decides pass/fail based on this.
-///
-/// `#[must_use]`: this struct carries individual policy outcomes
-/// (`signature_valid`, `mrtd_match`, `rtmr_matches`, ...). Dropping it
-/// without inspecting those booleans means a caller asked
-/// `attestation::verify(...)` and then ignored whether the quote actually
-/// matched the policy. That is *always* a bug — the attribute makes the
-/// compiler warn at every call site that throws the result away. Add an
-/// explicit `let _ = result;` only if you genuinely don't care.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[must_use]
 pub struct VerificationResult {
@@ -129,23 +114,16 @@ pub struct VerificationResult {
     /// Platform-specific collateral/TCB status details (TDX DCAP status, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tcb_status: Option<DcapVerificationStatus>,
-    /// Did the TDX MRTD (launch measurement) match the value supplied in
-    /// [`VerifyParams::expected_mrtd`]? `None` means no expected value was
-    /// provided. `Some(true)` / `Some(false)` reflect a constant-time compare.
-    /// Always `None` for SNP platforms.
+    /// MRTD compare result. `None` if no expected value was supplied.
+    /// Always `None` for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mrtd_match: Option<bool>,
-    /// Per-RTMR comparison results, matching the layout of
-    /// [`VerifyParams::expected_rtmrs`]. Inner `None` means no expected value
-    /// for that RTMR; `Some(bool)` is the constant-time-compare result.
-    /// The outer `None` means the caller provided no `expected_rtmrs` at all.
-    /// Always `None` for SNP platforms.
+    /// Per-RTMR compare results matching the layout of
+    /// [`VerifyParams::expected_rtmrs`]. Always `None` for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtmr_matches: Option<[Option<bool>; 4]>,
-    /// Did the SNP launch digest (report.measurement) match the value supplied
-    /// in [`VerifyParams::expected_launch_digest`]? `None` means no expected
-    /// value was provided. `Some(bool)` reflects a constant-time compare.
-    /// Always `None` for TDX platforms.
+    /// SNP launch digest compare result. `None` if no expected value was
+    /// supplied. Always `None` for TDX.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub launch_digest_match: Option<bool>,
 }

--- a/crates/attestation/src/types.rs
+++ b/crates/attestation/src/types.rs
@@ -77,10 +77,15 @@ pub struct VerifyParams {
     /// Expected MRTD. Result surfaces in [`VerificationResult::mrtd_match`];
     /// mismatch does not fail verification. TDX-only.
     pub expected_mrtd: Option<[u8; 48]>,
-    /// Expected RTMR[0..3] (inner `None` skips that RTMR). Results in
-    /// [`VerificationResult::rtmr_matches`]; mismatch does not fail
-    /// verification. TDX-only.
-    pub expected_rtmrs: Option<[Option<[u8; 48]>; 4]>,
+    /// Expected RTMR[0]. Result in [`VerificationResult::rtmr0_match`]; mismatch
+    /// does not fail verification. TDX-only.
+    pub expected_rtmr0: Option<[u8; 48]>,
+    /// Expected RTMR[1]. TDX-only.
+    pub expected_rtmr1: Option<[u8; 48]>,
+    /// Expected RTMR[2]. TDX-only.
+    pub expected_rtmr2: Option<[u8; 48]>,
+    /// Expected RTMR[3]. TDX-only.
+    pub expected_rtmr3: Option<[u8; 48]>,
     /// Expected SNP launch digest (`report.measurement`). Result in
     /// [`VerificationResult::launch_digest_match`]; mismatch does not fail
     /// verification. SNP-only.
@@ -118,10 +123,18 @@ pub struct VerificationResult {
     /// Always `None` for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mrtd_match: Option<bool>,
-    /// Per-RTMR compare results matching the layout of
-    /// [`VerifyParams::expected_rtmrs`]. Always `None` for SNP.
+    /// RTMR[0] compare result. Always `None` for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub rtmr_matches: Option<[Option<bool>; 4]>,
+    pub rtmr0_match: Option<bool>,
+    /// RTMR[1] compare result. Always `None` for SNP.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtmr1_match: Option<bool>,
+    /// RTMR[2] compare result. Always `None` for SNP.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtmr2_match: Option<bool>,
+    /// RTMR[3] compare result. Always `None` for SNP.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtmr3_match: Option<bool>,
     /// SNP launch digest compare result. `None` if no expected value was
     /// supplied. Always `None` for TDX.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

  Adds optional reference values to `VerifyParams` so callers can pin a TDX quote or SNP report against pre-computed measurements (`mrtd`, `rtmr0..3`, SNP launch digest). Results surface on `VerificationResult` as `Some(true)` / `Some(false)` per check, and the CLI exits non-zero on any explicit mismatch so CI/deploy gates fail closed when a pinned reference drifts.

  A mismatch does **not** fail the signature/collateral path, the result fields surface the outcome and the caller decides pass/fail. All comparisons are constant-time via `subtle::ConstantTimeEq`.

  ## Library (`attestation`)

  `VerifyParams` gains six optional fields:
  - `expected_mrtd: Option<[u8; 48]>` — TDX-only
  - `expected_rtmr0`, `expected_rtmr1`, `expected_rtmr2`, `expected_rtmr3: Option<[u8; 48]>` — TDX-only, independently optional
  - `expected_launch_digest: Option<[u8; 48]>`, SNP-only `VerificationResult` gains the matching outcome fields:
  - `mrtd_match`, `rtmr0_match`, `rtmr1_match`, `rtmr2_match`, `rtmr3_match`, `launch_digest_match` — all `Option<bool>` (`None` when no expected value was supplied)

  `VerificationResult` is marked `#[must_use]` so callers can't accidentally drop the policy outcomes.

  Wired through: bare-metal TDX, bare-metal SNP, Azure TDX (vTPM-wrapped), Azure SNP, GCP TDX, GCP SNP.

  ## CLI (`attestation-cli`)

  New `verify` flags mirroring the library fields:

  --expected-mrtd <HEX>
  --expected-rtmr0 <HEX>
  --expected-rtmr1 <HEX>
  --expected-rtmr2 <HEX>
  --expected-rtmr3 <HEX>
  --expected-launch-digest <HEX>

  Exit `1` on signature failure OR any explicit `--expected-*` mismatch. Exit `0` only on full match against everything the caller pinned.

  ## HTTP API (`attestation-api`)
Not surfaced in this PR. Adding the new fields needs a separate design pass on whether the server owns reference values (e.g. fetched from a manifest registry) or the client supplies them. Existing endpoints continue to work unchanged.

  ## Breaking changes

  None. All new fields are optional and default to `None`. Existing call sites that build `VerifyParams { ..Default::default() }` keep working.