### PR TITLE
ci: run the test suite inside a real SEV-SNP CVM on merge

### DIFF
--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -74,29 +74,58 @@ jobs:
           set -euo pipefail
           SHA='${{ github.sha }}'
           REPO='${{ github.repository }}'
+          # This heredoc builds the IN-GUEST payload (p.sh). Context: the CVM guest
+          # is a sealed, verity-measured image with NO toolchain and NO package
+          # manager, and NO credentials may enter it (delivery rides the serial
+          # console, which is logged). So the script below:
+          #   1. pulls the prebuilt test archive ANONYMOUSLY from the public
+          #      ghcr `ci-tests` package (built+pushed by the `archive` job for
+          #      this exact commit),
+          #   2. fetches a standalone cargo-nextest + this repo's source tree
+          #      (nextest needs it for --workspace-remap path fixups),
+          #   3. confirms it is really inside a TEE (/dev/sev-guest present),
+          #   4. runs the suite and reports via @@marker@@ lines that the lane
+          #      polls from the console log (@@PAYLOAD_OK@@ = the success gate).
           # Every in-guest network call is bounded: curl gets --connect-timeout/
           # --max-time/--retry; the python fallback passes urlopen(timeout=).
+          # NOTE: '#' comments below are for REVIEWERS — they are stripped before
+          # base64-encoding (every payload byte costs serial-console delivery time).
           cat > p.sh <<PAYLOAD
+          # dl(): bounded download with a python fallback (guest has curl+python3,
+          # no wget). Used for plain-HTTP fetches (nextest binary, source tarball).
           dl(){ curl -fsSL --connect-timeout 10 --max-time 300 --retry 3 --retry-all-errors "\$1" -o "\$2" 2>/dev/null || python3 -c "import urllib.request,shutil,sys; r=urllib.request.urlopen(sys.argv[1], timeout=60); f=open(sys.argv[2],'wb'); shutil.copyfileobj(r,f)" "\$1" "\$2"; }
           CURL="curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors"
+          # -- phase 1: anonymous ghcr pull of the ci-tests OCI artifact --------
+          # public package => the token endpoint hands out a pull token with NO
+          # auth; nothing secret ever enters the guest.
           TOK=\$(\$CURL "https://ghcr.io/token?scope=repository:$REPO/ci-tests:pull" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])' 2>/dev/null)
           [ -n "\$TOK" ] || { say FAIL_GHCR_TOKEN; exit 0; }
           M=\$(\$CURL -H "Authorization: Bearer \$TOK" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/$REPO/ci-tests/manifests/$SHA")
           printf '%s' "\$M" | python3 -c 'import json,sys; m=json.load(sys.stdin); [print(l.get("annotations",{}).get("org.opencontainers.image.title","blob"), l["digest"]) for l in m["layers"]]' > /tmp/layers.txt 2>/dev/null
           [ -s /tmp/layers.txt ] || { say FAIL_MANIFEST; exit 0; }
+          # the artifact has two layers, addressed by filename annotation:
+          #   tests.tar.zst = cargo-nextest archive of the compiled test binaries
+          #   libs.tar.gz   = the libtss2 .so's they link (guest ships none)
           while read -r name dgst; do
             \$CURL --max-time 300 -H "Authorization: Bearer \$TOK" "https://ghcr.io/v2/$REPO/ci-tests/blobs/\$dgst" -o "/tmp/\$name" || { say FAIL_ARCHIVE_PULL; exit 0; }
             echo "@@BLOB \$name \$(wc -c </tmp/\$name | tr -d ' ') bytes@@"
           done < /tmp/layers.txt
           [ -f /tmp/tests.tar.zst ] || { say FAIL_ARCHIVE_PULL; exit 0; }
           tar -xzf /tmp/libs.tar.gz -C /tmp 2>/dev/null && export LD_LIBRARY_PATH=/tmp/libs
+          # -- phase 2: standalone nextest + source tree (for --workspace-remap) --
           mkdir -p /tmp/nx
           dl "https://get.nexte.st/0.9/linux" /tmp/nx.tgz && tar -xzf /tmp/nx.tgz -C /tmp/nx || { say FAIL_NEXTEST_DL; exit 0; }
           dl "https://codeload.github.com/$REPO/tar.gz/$SHA" /tmp/src.tgz && tar -xzf /tmp/src.tgz -C /tmp || { say FAIL_SRC; exit 0; }
           SRC=\$(echo /tmp/attestation-rs-*)
           say TOOLS_READY
+          # -- phase 3: prove we are in a real TEE before trusting any result ----
+          # /tmp is the guest's tmpfs (~7.4G) — the / overlay is only 2G.
           echo "@@DF /tmp: \$(df -h /tmp 2>/dev/null | tail -1 | tr -s ' ')@@"
           [ -e /dev/sev-guest ] && say TEE_CONFIRMED || say TEE_MISSING
+          # -- phase 4: run the suite ------------------------------------------
+          # --run-ignored all : the TEE-gated #[ignore] tests are the whole point
+          # -E excludes capture_fixture: its variants need TDX/Azure, not bare SNP
+          # --extract-to must pre-exist (nextest canonicalizes before creating)
           export TMPDIR=/tmp
           mkdir -p /tmp/x
           /tmp/nx/cargo-nextest nextest run \
@@ -105,12 +134,15 @@ jobs:
             --run-ignored all -E 'not binary(capture_fixture)' \
             --no-fail-fast --hide-progress-bar > /tmp/nx.out 2>&1
           RC=\$?
+          # self-diagnose linkage: if any .so is missing, name it in the log
           B=\$(find /tmp/x -name 'attestation*' -type f -perm -u+x 2>/dev/null | head -1)
           if [ -n "\$B" ]; then ldd "\$B" 2>/dev/null | grep 'not found' | sed 's/^/@@LDD_MISSING /;s/\$/@@/'; fi
           grep -E 'PASS|FAIL|Summary|passed|failed|skipped' /tmp/nx.out | tail -25 | sed 's/^/@@NX /;s/\$/@@/'
           [ \$RC -eq 0 ] && say PAYLOAD_OK || { tail -30 /tmp/nx.out | sed 's/^/@@NXTAIL /;s/\$/@@/'; say FAIL_NEXTEST; }
           PAYLOAD
-          echo "b64=$(base64 -w0 p.sh)" >> "$GITHUB_OUTPUT"
+          # strip comment/blank lines before encoding — reviewer comments must not
+          # ride the serial console into the guest (delivery time ~ payload bytes)
+          echo "b64=$(grep -vE '^[[:space:]]*(#|$)' p.sh | base64 -w0)" >> "$GITHUB_OUTPUT"
 
   e2e:
     needs: [archive, payload]

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -115,6 +115,7 @@ jobs:
           echo "@@DF /tmp: \$(df -h /tmp 2>/dev/null | tail -1 | tr -s ' ')@@"
           [ -e /dev/sev-guest ] && say TEE_CONFIRMED || say TEE_MISSING
           export TMPDIR=/tmp
+          mkdir -p /tmp/x
           /tmp/nx/cargo-nextest nextest run \
             --archive-file /tmp/tests.tar.zst --workspace-remap "\$SRC" \
             --extract-to /tmp/x \

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -117,7 +117,7 @@ jobs:
           export TMPDIR=/tmp
           /tmp/nx/cargo-nextest nextest run \
             --archive-file /tmp/tests.tar.zst --workspace-remap "\$SRC" \
-            --extract-to /tmp/x --persist-extract-tempdir \
+            --extract-to /tmp/x \
             --run-ignored all -E 'not binary(capture_fixture)' \
             --no-fail-fast --hide-progress-bar > /tmp/nx.out 2>&1
           RC=\$?

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -1,0 +1,139 @@
+name: confidential-e2e
+# Run this library's own test suite INSIDE a real SEV-SNP CVM — the tests that
+# need genuine TEE hardware (/dev/sev-guest, configfs-tsm) and can never pass on
+# a GitHub-hosted runner:
+#   - the full workspace suite with the has_tee() branches on their REAL path
+#   - the #[ignore]d TEE tests (api_tests attest_endpoint / roundtrip)
+#   - the #[ignore]d network tests (SNP CRL verification against AMD KDS,
+#     live DCAP against Intel PCS) — the guest has egress
+# Excluded: capture_fixture (its TDX variant compiles under `attest` and cannot
+# pass on SNP); az_snp_live / az_tdx_live are cfg'd out by feature selection
+# (they need az-snp/az-tdx + an Azure CVM's vTPM/IMDS — that's the Azure lane's
+# unique coverage, not this one's).
+#
+# How: `cargo nextest archive` on ubuntu-22.04 (glibc 2.35 — the guest's must be
+# >= this) -> pushed to ghcr as an OCI artifact -> the CVM payload pulls it over
+# guest egress (anonymous; the ci-tests package is public) and executes it with
+# a standalone cargo-nextest. The CVM guest image is verity-immutable with NO
+# toolchain — the archive pattern is exactly for this.
+#
+# FLAVOR = rke2-node (not base-cpu): probed 2026-07-15, the base-cpu image is
+# console-silent after the EFI stub (no autologin -> no console delivery). The
+# rke2-node guest is the SAME genuine measured SEV-SNP CVM (/dev/sev-guest,
+# configfs-tsm) with a proven console; the k8s it boots is unused ballast here.
+# base-cpu returns when images grow an autologin console or the HTTP agent
+# transport (confidential-ci research/guest-transport.md).
+#
+# WHERE (boot/attest/teardown the CVM) is the confidential-ci primitive:
+#   confidential-dot-ai/confidential-ci/.github/workflows/cvm-e2e.yml
+# Trigger: push to main + dispatch. NEVER pull_request — this repo is public
+# and the job runs on org self-hosted hardware.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: confidential-e2e-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  NEXTEST_URL: https://get.nexte.st/0.9/linux   # same source in-guest — keep versions aligned
+  ORAS_VER: 1.2.0
+
+jobs:
+  # build the test archive OUTSIDE the TEE (the guest has no toolchain), publish
+  # it content-addressed by commit
+  archive:
+    runs-on: ubuntu-22.04   # glibc 2.35: forward-compatible with the guest's
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends libtss2-dev pkg-config
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: build test archive (--features attest, release = small enough for guest tmpfs)
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "$NEXTEST_URL" | tar -xz -C "$HOME/.local/bin" cargo-nextest
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/cargo-nextest" nextest archive --workspace --features attest \
+            --release --archive-file tests.tar.zst
+          ls -la tests.tar.zst
+      - name: 'bundle tss runtime libs (probe finding: guest ships no libtss2)'
+        run: |
+          set -euo pipefail
+          # --features attest links libtss2 dynamically (via az-cvm-vtpm -> tss-esapi).
+          # The guest image doesn't ship it; ship the builder's copies alongside the
+          # archive and LD_LIBRARY_PATH them in. (libcrypto/libssl exist in-guest —
+          # curl is present and links them; the payload ldd-checks and reports.)
+          mkdir -p libs && cp -av /usr/lib/x86_64-linux-gnu/libtss2*.so* libs/
+          tar -czf libs.tar.gz libs
+      - name: push archive + libs to ghcr (ci-tests package)
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VER}/oras_${ORAS_VER}_linux_amd64.tar.gz" | tar -xz oras
+          echo "${{ github.token }}" | ./oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          ./oras push "ghcr.io/${{ github.repository }}/ci-tests:${{ github.sha }}" tests.tar.zst libs.tar.gz
+          # ONE-TIME after the first push: set the ci-tests package public
+          # (org settings -> packages) so the in-guest pull needs no credential.
+          # Until then the in-guest anonymous pull 401s -> FAIL_GHCR_TOKEN/FAIL_MANIFEST.
+
+  # the in-guest script: pull archive + standalone nextest + source tree, run
+  payload:
+    runs-on: ubuntu-latest
+    outputs:
+      b64: ${{ steps.p.outputs.b64 }}
+    steps:
+      - id: p
+        run: |
+          set -euo pipefail
+          SHA='${{ github.sha }}'
+          REPO='${{ github.repository }}'
+          cat > p.sh <<PAYLOAD
+          dl(){ curl -fsSL --retry 3 "\$1" -o "\$2" 2>/dev/null || python3 -c "import urllib.request,sys; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])" "\$1" "\$2"; }
+          TOK=\$(curl -fsSL "https://ghcr.io/token?scope=repository:$REPO/ci-tests:pull" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+          [ -n "\$TOK" ] || { say FAIL_GHCR_TOKEN; exit 0; }
+          M=\$(curl -fsSL -H "Authorization: Bearer \$TOK" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/$REPO/ci-tests/manifests/$SHA")
+          printf '%s' "\$M" | python3 -c 'import json,sys; m=json.load(sys.stdin); [print(l.get("annotations",{}).get("org.opencontainers.image.title","blob"), l["digest"]) for l in m["layers"]]' > /tmp/layers.txt 2>/dev/null
+          [ -s /tmp/layers.txt ] || { say FAIL_MANIFEST; exit 0; }
+          while read -r name dgst; do
+            curl -fsSL -H "Authorization: Bearer \$TOK" "https://ghcr.io/v2/$REPO/ci-tests/blobs/\$dgst" -o "/tmp/\$name" || { say FAIL_ARCHIVE_PULL; exit 0; }
+            echo "@@BLOB \$name \$(wc -c </tmp/\$name | tr -d ' ') bytes@@"
+          done < /tmp/layers.txt
+          [ -f /tmp/tests.tar.zst ] || { say FAIL_ARCHIVE_PULL; exit 0; }
+          tar -xzf /tmp/libs.tar.gz -C /tmp 2>/dev/null && export LD_LIBRARY_PATH=/tmp/libs
+          mkdir -p /tmp/nx
+          dl "https://get.nexte.st/0.9/linux" /tmp/nx.tgz && tar -xzf /tmp/nx.tgz -C /tmp/nx || { say FAIL_NEXTEST_DL; exit 0; }
+          dl "https://codeload.github.com/$REPO/tar.gz/$SHA" /tmp/src.tgz && tar -xzf /tmp/src.tgz -C /tmp || { say FAIL_SRC; exit 0; }
+          SRC=\$(echo /tmp/attestation-rs-*)
+          say TOOLS_READY
+          echo "@@DF /tmp: \$(df -h /tmp 2>/dev/null | tail -1 | tr -s ' ')@@"
+          [ -e /dev/sev-guest ] && say TEE_CONFIRMED || say TEE_MISSING
+          export TMPDIR=/tmp
+          /tmp/nx/cargo-nextest nextest run \
+            --archive-file /tmp/tests.tar.zst --workspace-remap "\$SRC" \
+            --extract-to /tmp/x --persist-extract-tempdir \
+            --run-ignored all -E 'not binary(capture_fixture)' \
+            --no-fail-fast --hide-progress-bar > /tmp/nx.out 2>&1
+          RC=\$?
+          B=\$(find /tmp/x -name 'attestation*' -type f -perm -u+x 2>/dev/null | head -1)
+          if [ -n "\$B" ]; then ldd "\$B" 2>/dev/null | grep 'not found' | sed 's/^/@@LDD_MISSING /;s/\$/@@/'; fi
+          grep -E 'PASS|FAIL|Summary|passed|failed|skipped' /tmp/nx.out | tail -25 | sed 's/^/@@NX /;s/\$/@@/'
+          [ \$RC -eq 0 ] && say PAYLOAD_OK || { tail -30 /tmp/nx.out | sed 's/^/@@NXTAIL /;s/\$/@@/'; say FAIL_NEXTEST; }
+          PAYLOAD
+          echo "b64=$(base64 -w0 p.sh)" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    needs: [archive, payload]
+    uses: confidential-dot-ai/confidential-ci/.github/workflows/cvm-e2e.yml@main
+    with:
+      platform: snp-metal
+      runner: cvm-launcher
+      flavor: rke2-node
+      payload_b64: ${{ needs.payload.outputs.b64 }}
+      timeout_minutes: 40

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -1,41 +1,21 @@
 name: confidential-e2e
-# Run this library's own test suite INSIDE a real SEV-SNP CVM — the tests that
-# need genuine TEE hardware (/dev/sev-guest, configfs-tsm) and can never pass on
-# a GitHub-hosted runner:
-#   - the full workspace suite with the has_tee() branches on their REAL path
-#   - the #[ignore]d TEE tests (api_tests attest_endpoint / roundtrip)
-#   - the #[ignore]d network tests (SNP CRL verification against AMD KDS,
-#     live DCAP against Intel PCS) — the guest has egress
-# Excluded: capture_fixture (its TDX variant compiles under `attest` and cannot
-# pass on SNP); az_snp_live / az_tdx_live are cfg'd out by feature selection
-# (they need az-snp/az-tdx + an Azure CVM's vTPM/IMDS — that's the Azure lane's
-# unique coverage, not this one's).
-#
-# How: `cargo nextest archive` on ubuntu-22.04 (glibc 2.35 — the guest's must be
-# >= this) -> pushed to ghcr as an OCI artifact -> the CVM payload pulls it over
-# guest egress (anonymous; the ci-tests package is public) and executes it with
-# a standalone cargo-nextest. The CVM guest image is verity-immutable with NO
-# toolchain — the archive pattern is exactly for this.
-#
-# FLAVOR = rke2-node (not base-cpu): probed 2026-07-15, the base-cpu image is
-# console-silent after the EFI stub (no autologin -> no console delivery). The
-# rke2-node guest is the SAME genuine measured SEV-SNP CVM (/dev/sev-guest,
-# configfs-tsm) with a proven console; the k8s it boots is unused ballast here.
-# base-cpu returns when images grow an autologin console or the HTTP agent
-# transport (confidential-ci research/guest-transport.md).
-#
-# WHERE (boot/attest/teardown the CVM) is the confidential-ci primitive:
-#   confidential-dot-ai/confidential-ci/.github/workflows/cvm-e2e.yml
-# Trigger: push to main + dispatch. NEVER pull_request — this repo is public
-# and the job runs on org self-hosted hardware.
+# Run this library's own test suite INSIDE a real SEV-SNP CVM — the TEE-gated
+# paths (/dev/sev-guest, configfs-tsm) that can never pass on a hosted runner.
+# Build the suite as a `cargo nextest archive` outside the TEE, pull it into a
+# measured CVM over guest egress, run it there. Excludes capture_fixture (TDX
+# variant, can't pass on SNP); az_snp_live/az_tdx_live are the Azure lane's.
+# FLAVOR=rke2-node (base-cpu is console-dead) and the full rationale + the
+# one-time ci-tests package steps live in the repo README (Confidential e2e)
+# and confidential-dot-ai/confidential-ci/USING-THE-PRIMITIVE.md.
+# Trigger: push:main + dispatch. NEVER pull_request (org self-hosted hardware).
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
+# Least privilege at the top; only the archive job is granted packages: write.
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: confidential-e2e-${{ github.sha }}
@@ -50,6 +30,9 @@ jobs:
   # it content-addressed by commit
   archive:
     runs-on: ubuntu-22.04   # glibc 2.35: forward-compatible with the guest's
+    permissions:
+      contents: read
+      packages: write       # only this job pushes the ci-tests OCI artifact
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends libtss2-dev pkg-config
@@ -59,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL "$NEXTEST_URL" | tar -xz -C "$HOME/.local/bin" cargo-nextest
+          curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$NEXTEST_URL" | tar -xz -C "$HOME/.local/bin" cargo-nextest
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/cargo-nextest" nextest archive --workspace --features attest \
             --release --archive-file tests.tar.zst
@@ -67,21 +50,18 @@ jobs:
       - name: 'bundle tss runtime libs (probe finding: guest ships no libtss2)'
         run: |
           set -euo pipefail
-          # --features attest links libtss2 dynamically (via az-cvm-vtpm -> tss-esapi).
-          # The guest image doesn't ship it; ship the builder's copies alongside the
-          # archive and LD_LIBRARY_PATH them in. (libcrypto/libssl exist in-guest —
-          # curl is present and links them; the payload ldd-checks and reports.)
+          # --features attest links libtss2 dynamically (az-cvm-vtpm -> tss-esapi);
+          # the guest ships none, so ship the builder's .so's beside the archive.
           mkdir -p libs && cp -av /usr/lib/x86_64-linux-gnu/libtss2*.so* libs/
           tar -czf libs.tar.gz libs
       - name: push archive + libs to ghcr (ci-tests package)
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VER}/oras_${ORAS_VER}_linux_amd64.tar.gz" | tar -xz oras
+          curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "https://github.com/oras-project/oras/releases/download/v${ORAS_VER}/oras_${ORAS_VER}_linux_amd64.tar.gz" | tar -xz oras
           echo "${{ github.token }}" | ./oras login ghcr.io -u "${{ github.actor }}" --password-stdin
           ./oras push "ghcr.io/${{ github.repository }}/ci-tests:${{ github.sha }}" tests.tar.zst libs.tar.gz
-          # ONE-TIME after the first push: set the ci-tests package public
-          # (org settings -> packages) so the in-guest pull needs no credential.
-          # Until then the in-guest anonymous pull 401s -> FAIL_GHCR_TOKEN/FAIL_MANIFEST.
+          # ONE-TIME after the first push: set the ci-tests package public + repo
+          # role Write (org -> packages). See the repo README (Confidential e2e).
 
   # the in-guest script: pull archive + standalone nextest + source tree, run
   payload:
@@ -94,15 +74,18 @@ jobs:
           set -euo pipefail
           SHA='${{ github.sha }}'
           REPO='${{ github.repository }}'
+          # Every in-guest network call is bounded: curl gets --connect-timeout/
+          # --max-time/--retry; the python fallback passes urlopen(timeout=).
           cat > p.sh <<PAYLOAD
-          dl(){ curl -fsSL --retry 3 "\$1" -o "\$2" 2>/dev/null || python3 -c "import urllib.request,sys; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])" "\$1" "\$2"; }
-          TOK=\$(curl -fsSL "https://ghcr.io/token?scope=repository:$REPO/ci-tests:pull" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+          dl(){ curl -fsSL --connect-timeout 10 --max-time 300 --retry 3 --retry-all-errors "\$1" -o "\$2" 2>/dev/null || python3 -c "import urllib.request,shutil,sys; r=urllib.request.urlopen(sys.argv[1], timeout=60); f=open(sys.argv[2],'wb'); shutil.copyfileobj(r,f)" "\$1" "\$2"; }
+          CURL="curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors"
+          TOK=\$(\$CURL "https://ghcr.io/token?scope=repository:$REPO/ci-tests:pull" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])' 2>/dev/null)
           [ -n "\$TOK" ] || { say FAIL_GHCR_TOKEN; exit 0; }
-          M=\$(curl -fsSL -H "Authorization: Bearer \$TOK" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/$REPO/ci-tests/manifests/$SHA")
+          M=\$(\$CURL -H "Authorization: Bearer \$TOK" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/$REPO/ci-tests/manifests/$SHA")
           printf '%s' "\$M" | python3 -c 'import json,sys; m=json.load(sys.stdin); [print(l.get("annotations",{}).get("org.opencontainers.image.title","blob"), l["digest"]) for l in m["layers"]]' > /tmp/layers.txt 2>/dev/null
           [ -s /tmp/layers.txt ] || { say FAIL_MANIFEST; exit 0; }
           while read -r name dgst; do
-            curl -fsSL -H "Authorization: Bearer \$TOK" "https://ghcr.io/v2/$REPO/ci-tests/blobs/\$dgst" -o "/tmp/\$name" || { say FAIL_ARCHIVE_PULL; exit 0; }
+            \$CURL --max-time 300 -H "Authorization: Bearer \$TOK" "https://ghcr.io/v2/$REPO/ci-tests/blobs/\$dgst" -o "/tmp/\$name" || { say FAIL_ARCHIVE_PULL; exit 0; }
             echo "@@BLOB \$name \$(wc -c </tmp/\$name | tr -d ' ') bytes@@"
           done < /tmp/layers.txt
           [ -f /tmp/tests.tar.zst ] || { say FAIL_ARCHIVE_PULL; exit 0; }
@@ -131,7 +114,8 @@ jobs:
 
   e2e:
     needs: [archive, payload]
-    uses: confidential-dot-ai/confidential-ci/.github/workflows/cvm-e2e.yml@main
+    # Reusable lane pinned by commit SHA (bump deliberately); @main is a label.
+    uses: confidential-dot-ai/confidential-ci/.github/workflows/cvm-e2e.yml@cad0dd13ac445188a3bd1641b6506c45658f274f
     with:
       platform: snp-metal
       runner: cvm-launcher

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -149,3 +149,18 @@ CI gate using these flags fails closed on a wrong workload.
 
 - Core library: `crates/attestation/README.md`
 - REST service: `crates/attestation-api/README.md`
+
+## Confidential e2e (SNP-metal)
+
+`.github/workflows/confidential-e2e.yml` runs this workspace's TEE-gated tests
+**inside a real SEV-SNP CVM** on every push to `main` (and via dispatch) — the
+`has_tee()` real paths, the `#[ignore]`d attest tests, and the network CRL/DCAP
+tests, none of which can pass on a hosted runner. It builds a `cargo nextest
+archive` outside the TEE, pulls it into a measured CVM, and runs it there via
+the confidential-ci `cvm-e2e` primitive. `az_snp_live`/`az_tdx_live` run on the
+Azure lane instead (vTPM). Never `pull_request` — org self-hosted hardware.
+
+One-time after the first run: set the auto-created `ci-tests` package **public**
+and the repo's role on it to **Write** (org → Packages). Details and the
+matrix/dispatcher pattern: confidential-dot-ai/confidential-ci
+`USING-THE-PRIMITIVE.md`.


### PR DESCRIPTION
## What

This is the vision's motivating example ("push a change to the attestation lib → e2e tests prove it still produces valid attestations") for the SNP-metal cell.

Every main merge (+ dispatch):
1. **archive** — `cargo nextest archive --workspace --features attest` on `ubuntu-22.04`, pushed to `ghcr.io/confidential-dot-ai/attestation-rs/ci-tests:<sha>` together with the libtss2 runtime `.so`s (the guest image ships none — probed live).
2. **e2e** — the confidential-ci primitive (`cvm-e2e.yml`) boots a **measured SEV-SNP CVM** (KubeVirt, IGVM, runtime launch measurement self-discovered via configfs-tsm), and the payload pulls the archive anonymously and runs it with a standalone `cargo-nextest` — `--run-ignored all`, excluding `capture_fixture` (its TDX variant can't pass on SNP; `az_*_live` are cfg'd out by feature selection — that's the future Azure lane's unique coverage).

What this adds over hosted CI: the `has_tee()` branches take their real path against `/dev/sev-guest`, the `#[ignore]`d TEE tests (`api_tests::attest_endpoint`, `attest_then_verify_roundtrip`) actually run, and the network-`#[ignore]`d CRL/PCS tests run over guest egress.

## Pre-verified (so review is about intent, not plumbing)

- guest probed live on the target cell: glibc 2.43 (≥ builder's 2.35), python3/curl/tar present, egress + ghcr reachable, `/dev/sev-guest` + configfs-tsm present
- payload heredoc round-trips validated locally (`bash -n` on the generated script)
- runner group already allows public repos (same approved pattern as `the-machine` in c8s)

## One-time steps after first merge (both found live in the pre-merge rehearsal)

1. The first run's in-guest pull will 401 until the auto-created `ci-tests` package is flipped to **public** (org → packages → ci-tests → visibility).
2. After the flip, the repo's role on the package's **Manage Actions access** list may be `Read` — subsequent archive pushes then fail `permission_denied: write_package`. Set the repo's role to **Write** on the same settings page.

Both verified against the rehearsal package; second run onward is fully green-path. No secrets anywhere in the lane.

## Triggers

`push: main` + `workflow_dispatch` only — **never `pull_request`** (public repo, org self-hosted hardware).
