### PR TITLE
test(az-snp): fix the two az_snp_live bugs surfaced on real Azure vTPM hardware

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+# The Azure vTPM is a single serialized device. nextest runs each test in its own
+# process, defaulting to one per vCPU, so the az_* live tests raced each other on
+# /dev/tpmrm0 and the loser got `vtpm::get_report failed: tpm error`. These tests
+# are #[ignore]d and only run on real CVM hardware, so the race stayed latent.
+[test-groups]
+vtpm = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'binary(az_snp_live) or binary(az_tdx_live)'
+test-group = 'vtpm'

--- a/crates/attestation/tests/az_snp_live.rs
+++ b/crates/attestation/tests/az_snp_live.rs
@@ -204,12 +204,11 @@ async fn test_az_snp_verify_with_expected_nonce() {
         .await
         .expect("generate_evidence() should succeed");
 
-    // Verify with correct nonce
-    let mut padded_nonce = vec![0u8; 64];
-    padded_nonce[..nonce.len()].copy_from_slice(nonce);
-
+    // Verify with correct nonce. Pass it unpadded: attest::generate_evidence puts
+    // report_data verbatim into the TPM nonce, and verify_tpm_nonce requires the
+    // expectation to be the same length as that nonce.
     let params = VerifyParams {
-        expected_report_data: Some(padded_nonce),
+        expected_report_data: Some(nonce.to_vec()),
         expected_init_data_hash: None,
         ..Default::default()
     };


### PR DESCRIPTION
The `az_snp_live` tests are `#[ignore]`d and never run in ubuntu-latest CI, so two bugs sat latent until the confidential-ci Azure lane ran them on a real SEV-SNP CVM (`Standard_DC2as_v5`, vTPM) on 2026-07-16. Observed result there: **6 tests run, 3 passed, 3 failed.**

Two independent root causes. Both are test bugs — no production code is changed.

## 1. Nonce padding (`test_az_snp_verify_with_expected_nonce`)

```
verify should succeed: QuoteParseFailed("TPM nonce length mismatch")
```

The test padded the expected nonce to 64 bytes before passing it as `VerifyParams.expected_report_data`. But `az_snp/attest.rs` deliberately keeps `report_data` **unpadded** — `vtpm::get_quote` puts the bytes verbatim into the TPM nonce, and `tpm_common::verify_tpm_nonce` requires `nonce.len() == expected.len()`. A 64-byte expectation against a 23-byte quote nonce can never match.

`az_tdx_live.rs` already passes its nonce unpadded against the same `VerifyParams`; `az_snp_live` was the lone outlier. This aligns it.

## 2. vTPM contention (`test_az_snp_attest_generates_valid_evidence`, `test_az_snp_hcl_report_contains_snp_report`)

```
generate_evidence() should succeed: HardwareAccessFailed("vtpm::get_report failed: tpm error")
```

This one is **not** a code defect, and it fails at `vtpm::get_report` — before any HCL parsing or nonce logic. The proof:

| test | nonce | result |
|---|---|---|
| `test_az_snp_attest_generates_valid_evidence` | 30 bytes | **FAIL** @ 0.043s |
| `test_az_snp_attest_then_verify_roundtrip` | 31 bytes | **PASS** @ 3.932s |

Same function, near-identical input, opposite outcomes inside one 5-second window. Nothing deterministic separates them.

What does separate them is timing. The six test durations sum to 10.6s against 5.322s wall — **1.99x parallelism**. nextest runs one process per vCPU, so on a 2-vCPU `DC2as_v5` two processes hit `/dev/tpmrm0` simultaneously. Azure's emulated vTPM has limited session slots; the loser gets `tpm error`.

The fix puts `az_snp_live` and `az_tdx_live` into a `max-threads = 1` nextest group. It lives in `.config/nextest.toml` rather than a CI flag so local runs and every lane inherit it.

## Verification status

Please read this honestly — I want the hardware run to be the arbiter, not my reasoning.

- **The nextest config is verified.** nextest validates filterset syntax and group references before compiling (confirmed by deliberately breaking both), and `show-config test-groups` resolves the group. `binary(az_snp_live)` is proven to select exactly these 6 tests on linux by the lane's own `-E` filterset.
- **The Rust change is *not* locally compiled.** `az_snp::attest` is gated behind `target_os = "linux"`, and cross-checking dies on `tss-esapi-sys` needing a pkg-config sysroot. The change is `Vec<u8>` -> `Vec<u8>`, so type risk is nil — but it is unverified until this runs on hardware.

The real check is one `rehearse-ars-e2e` run with `ars_ref` pointed at this branch. **Expect 6/6, with wall time rising to roughly the ~10.6s serial sum** (that rise is the signal the serialization actually took effect).

If tests 2 and 3 still fail after serialization, the contention diagnosis is wrong and the next suspect is session exhaustion *within* a single `get_report`, which would argue for retry logic in `attest.rs` — but that should be driven by evidence, not added speculatively.
