### PR TITLE
fix(wasm): enforce VMPL==0 and reject debug-policy guests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "base64 0.22.1",
  "serde_json",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/crates/attestation-wasm/Cargo.toml
+++ b/crates/attestation-wasm/Cargo.toml
@@ -9,5 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 attestation = { path = "../attestation" }
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 serde_json = "1"
 base64 = "0.22"

--- a/crates/attestation-wasm/src/lib.rs
+++ b/crates/attestation-wasm/src/lib.rs
@@ -213,6 +213,5 @@ pub async fn verify_az_tdx(
         .await
         .map_err(|e| JsError::new(&format!("az-tdx verify: {e}")))?;
 
-    serde_json::to_string_pretty(&result)
-        .map_err(|e| JsError::new(&format!("json serialize: {e}")))
+    serde_json::to_string_pretty(&result).map_err(|e| JsError::new(&format!("json serialize: {e}")))
 }

--- a/crates/attestation-wasm/src/lib.rs
+++ b/crates/attestation-wasm/src/lib.rs
@@ -2,6 +2,8 @@ use wasm_bindgen::prelude::*;
 
 use attestation::platforms::az_snp::evidence::AzSnpEvidence;
 use attestation::platforms::az_snp::verify::verify_report;
+use attestation::platforms::az_tdx::evidence::AzTdxEvidence;
+use attestation::platforms::az_tdx::verify::verify_evidence as verify_az_tdx_evidence;
 use attestation::platforms::snp::certs::get_bundled_certs;
 use attestation::platforms::snp::claims::extract_claims;
 use attestation::platforms::snp::verify::{
@@ -156,4 +158,61 @@ pub fn verify_az_snp(
     result["report_version"] = serde_json::json!(verified.report_version);
 
     serde_json::to_string_pretty(&result).map_err(|e| JsError::new(&format!("json serialize: {e}")))
+}
+
+/// Verify Azure TDX (az-tdx) vTPM attestation evidence in WASM.
+///
+/// The Azure TDX shape mirrors az-snp: the freshness anchor lives in the vTPM
+/// quote's `extraData` (qualifyingData), while the Intel-signed TD quote's
+/// `report_data` binds the vTPM attestation key (AK). Verification order
+/// (see `platforms/az_tdx/verify.rs`):
+/// 1. Parse the HCL report and require `report_type == TDX`.
+/// 2. Verify the vTPM quote signature with the AK extracted from HCL var_data.
+/// 3. Check the quote's `extraData` equals `expected_report_data` (freshness),
+///    failing closed when an anchor is supplied and does not match.
+/// 4. Verify the PCR digest, and optionally bind PCR[8] to `expected_init_data_hash`.
+/// 5. Parse the TD quote, verify its ECDSA signature, and verify the DCAP chain
+///    to the pinned Intel SGX Root CA.
+/// 6. Enforce the TD debug-attribute policy (reject debug TDs — no opt-in here).
+/// 7. Bind the AK to the TEE: `td_report.report_data[..32] == SHA-256(var_data)`.
+///
+/// Like [`verify_az_snp`], the DCAP **collateral** checks (PCK CRL, TCB status,
+/// TD-QE identity) need an async provider and are skipped in WASM, so
+/// `collateral_verified` is always `false`. The measurement surfaces as
+/// `claims.launch_digest` = hex(MRTD); MRTD/RTMR pinning is the JS policy
+/// layer's job (a mismatch is reported, not fatal, in the core).
+///
+/// - `evidence_json`: az-tdx evidence JSON (`{ version, tpm_quote, hcl_report, td_quote }`)
+/// - `expected_report_data`: optional raw bytes the TPM quote `extraData` must equal
+/// - `expected_init_data_hash`: optional 32-byte hash to bind against PCR[8]
+///
+/// Returns the verification result as JSON, or throws on any check failure.
+///
+/// This is `async` (unlike `verify_az_snp`, whose core is sync) because the
+/// shared az-tdx core is `async` for its optional collateral provider; with a
+/// `None` provider it performs no actual awaiting. Callers `await` the returned
+/// Promise.
+#[wasm_bindgen]
+pub async fn verify_az_tdx(
+    evidence_json: String,
+    expected_report_data: Option<Vec<u8>>,
+    expected_init_data_hash: Option<Vec<u8>>,
+) -> Result<String, JsError> {
+    let evidence: AzTdxEvidence = serde_json::from_str(&evidence_json)
+        .map_err(|e| JsError::new(&format!("evidence deserialize: {e}")))?;
+
+    let params = VerifyParams {
+        expected_report_data,
+        expected_init_data_hash,
+        ..VerifyParams::default()
+    };
+
+    // None collateral provider: CRL/TCB/QE-identity checks are skipped (same
+    // trade-off verify_az_snp documents), collateral_verified stays false.
+    let result = verify_az_tdx_evidence(&evidence, &params, None)
+        .await
+        .map_err(|e| JsError::new(&format!("az-tdx verify: {e}")))?;
+
+    serde_json::to_string_pretty(&result)
+        .map_err(|e| JsError::new(&format!("json serialize: {e}")))
 }

--- a/crates/attestation-wasm/src/lib.rs
+++ b/crates/attestation-wasm/src/lib.rs
@@ -59,6 +59,28 @@ pub fn verify_snp(
     verify_report_signature(&report_bytes, &vcek_der)
         .map_err(|e| JsError::new(&format!("report signature: {e}")))?;
 
+    // Guest-policy enforcement — mirrors the native `verify_report` path
+    // (`platforms/snp/verify.rs`: VMPL==0 and debug-policy rejection). Without
+    // these, a malicious host can launch the *correctly-measured* image as a
+    // debug-enabled or non-VMPL-0 SNP guest: the launch_digest still matches a
+    // pinned allowlist, the VCEK chain and report signature are genuine, and
+    // report_data still binds the session key — yet the hypervisor can read the
+    // guest's memory (debug) or a lower-privilege VMPL can, so it extracts the
+    // session key and reads the "confidential" channel. The browser entry has no
+    // `allow_debug` opt-in: it fails closed. (SEV-SNP guest policy lives in the
+    // report, not the launch measurement, so a measurement pin cannot catch this.)
+    if report.vmpl != 0 {
+        return Err(JsError::new(&format!(
+            "VMPL check failed: report VMPL is {} (expected 0)",
+            report.vmpl
+        )));
+    }
+    if report.policy.debug_allowed() {
+        return Err(JsError::new(
+            "SNP guest policy permits debug (host can read guest memory); rejecting (fail closed)",
+        ));
+    }
+
     // Check report_data binding
     let report_data_match = expected_report_data.map(|expected| {
         let padded = pad_report_data(&expected, 64).unwrap_or_default();

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -103,6 +103,14 @@ getrandom = { version = "0.2", features = ["js"] }
 # which panics on that target — trapping every real EAT/cert expiry check in
 # the browser (see verify.rs `exp`/validity enforcement).
 chrono = { version = "0.4", default-features = false, features = ["std", "now", "wasmbind"] }
+# `x509-parser`'s `ASN1Time::now()` (used for cert notBefore/notAfter checks in
+# the TDX DCAP chain — see `platforms/tdx/dcap.rs`) resolves through the `time`
+# crate's `OffsetDateTime::now_utc()`, which panics on wasm32-unknown-unknown
+# unless `time`'s wasm backend is enabled. `wasm-bindgen` routes it through
+# `js_sys::Date`. Without this, `verify_az_tdx` traps ("unreachable") the moment
+# it validates the PCK certificate chain. (The SNP wasm entrypoints never reach a
+# validity check, which is why only the TDX path needed this.)
+time = { version = "0.3", default-features = false, features = ["wasm-bindgen"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
The wasm `verify_snp` entrypoint verified the VCEK chain, the report signature and the report_data binding, but, unlike the native `platforms/snp/verify.rs` path, never checked the guest policy.
It accepted a genuine, correctly-measured SNP report regardless of the VMPL it was issued at or whether the guest policy permits debug.

SEV-SNP guest policy (debug bit, VMPL) lives in the report, not in the launch measurement, so a measurement allowlist cannot catch this. A malicious host could launch the correct, pinned c8s image as a debug-enabled (or non-VMPL-0) SNP guest: launch_digest still matches, the VCEK chain and signature are genuine, report_data still binds the session key, yet the hypervisor can read guest memory and extract the session key, defeating channel confidentiality even with a correct measurement + mesh-CA pin.

Mirror the native checks (VMPL==0, reject debug policy). The browser entry has no allow_debug opt-in: it fails closed. Genuine production evidence is VMPL 0 and non-debug, so real fixtures are unaffected.