### PR TITLE
fix(tpm): require PCR[8] in the signed selection before trusting init-data

### DIFF
--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -206,8 +206,11 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
     }
 
     // Init data and result
-    let init_data_match =
-        tpm_common::check_init_data(&tpm_pcrs, params.expected_init_data_hash.as_deref())?;
+    let init_data_match = tpm_common::check_init_data(
+        &tpm_msg,
+        &tpm_pcrs,
+        params.expected_init_data_hash.as_deref(),
+    )?;
 
     // Optional launch-digest compare. Mismatch surfaces in the result and
     // does not fail verification.

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -122,8 +122,11 @@ pub async fn verify_evidence(
 
     // Bindings
     tpm_common::verify_hcl_var_data_binding(&tdx_quote.body.report_data, &hcl.var_data)?;
-    let init_data_match =
-        tpm_common::check_init_data(&tpm_pcrs, params.expected_init_data_hash.as_deref())?;
+    let init_data_match = tpm_common::check_init_data(
+        &tpm_msg,
+        &tpm_pcrs,
+        params.expected_init_data_hash.as_deref(),
+    )?;
 
     // Optional MRTD / RTMR compares. Mismatches surface in the result and
     // do not fail verification.

--- a/crates/attestation/src/platforms/tpm_common.rs
+++ b/crates/attestation/src/platforms/tpm_common.rs
@@ -647,7 +647,21 @@ pub fn check_report_data(tpm_msg: &[u8], expected: Option<&[u8]>) -> Result<Opti
 /// TPM PCR extend semantics: `PCR[8] = SHA256(zeros_32 || init_data_hash)`.
 /// The guest extends PCR[8] from its initial zero state with the init_data hash,
 /// so we must replicate that extend operation before comparing.
-pub fn check_init_data(tpm_pcrs: &[Vec<u8>], expected: Option<&[u8]>) -> Result<Option<bool>> {
+///
+/// `tpm_pcrs` is attacker-supplied data carried alongside the quote: a
+/// `TPM2_Quote` signs only a `pcrDigest` over the PCRs named in its `pcrSelect`,
+/// so `verify_tpm_pcrs` authenticates `tpm_pcrs[i]` only for `i` in that
+/// selection. Any entry outside it is unauthenticated. We therefore re-derive
+/// the signed selection from the (already signature-verified) quote message and
+/// require index 8 to be present before trusting `tpm_pcrs[8]`.
+///
+/// Callers MUST have verified the quote signature and called `verify_tpm_pcrs`
+/// before calling this.
+pub fn check_init_data(
+    tpm_msg: &[u8],
+    tpm_pcrs: &[Vec<u8>],
+    expected: Option<&[u8]>,
+) -> Result<Option<bool>> {
     let Some(expected) = expected else {
         return Ok(None);
     };
@@ -657,8 +671,19 @@ pub fn check_init_data(tpm_pcrs: &[Vec<u8>], expected: Option<&[u8]>) -> Result<
             expected.len()
         )));
     }
+    let (selected_pcrs, _) = parse_quote_info(tpm_msg)?;
+    if !selected_pcrs.contains(&8) {
+        return Err(AttestationError::QuoteParseFailed(
+            "init_data check requires PCR[8], but it is not in the quote's signed PCR selection \
+             (the supplied value would be unauthenticated)"
+                .to_string(),
+        ));
+    }
     if tpm_pcrs.len() <= 8 {
-        return Err(AttestationError::InitDataMismatch);
+        return Err(AttestationError::QuoteParseFailed(format!(
+            "init_data check requires PCR[8], but only {} PCR values were supplied",
+            tpm_pcrs.len()
+        )));
     }
     // Compute TPM PCR extend: PCR[8] = SHA256(zeros_32 || init_data_hash)
     let extended = crate::utils::sha256_two(&[0u8; 32], expected);
@@ -1407,10 +1432,16 @@ mod tests {
 
     // --- check_init_data tests ---
 
+    /// A quote message whose signed PCR selection covers PCRs 0-8.
+    fn attest_selecting_pcr8() -> Vec<u8> {
+        // sizeofSelect=3, bitmap [0xFF, 0x01, 0x00]: PCRs 0-7 plus PCR 8.
+        build_tpms_attest(&[0u8; 32], &[3, 0xFF, 0x01, 0x00], &[0u8; 32])
+    }
+
     #[test]
     fn test_check_init_data_none_expected() {
         let pcrs = vec![vec![0u8; 32]; 16];
-        let result = check_init_data(&pcrs, None);
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
     }
@@ -1424,7 +1455,7 @@ mod tests {
         let mut pcrs = vec![vec![0u8; 32]; 16];
         pcrs[8] = extended;
 
-        let result = check_init_data(&pcrs, Some(&init_data_hash));
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, Some(&init_data_hash));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(true));
     }
@@ -1432,13 +1463,12 @@ mod tests {
     #[test]
     fn test_check_init_data_raw_hash_mismatch() {
         // If PCR[8] contains the raw hash (not extended), it should NOT match.
-        // This is the bug this fix corrects.
         let init_data_hash = [0xBB; 32];
 
         let mut pcrs = vec![vec![0u8; 32]; 16];
         pcrs[8] = init_data_hash.to_vec(); // raw, not extended
 
-        let result = check_init_data(&pcrs, Some(&init_data_hash));
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, Some(&init_data_hash));
         assert!(
             result.is_err(),
             "raw hash should not match extended PCR value"
@@ -1454,21 +1484,74 @@ mod tests {
         let mut pcrs = vec![vec![0u8; 32]; 16];
         pcrs[8] = extended;
 
-        let result = check_init_data(&pcrs, Some(&init_data_hash));
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, Some(&init_data_hash));
         assert!(result.is_err());
     }
 
     #[test]
     fn test_check_init_data_wrong_length() {
         let pcrs = vec![vec![0u8; 32]; 16];
-        let result = check_init_data(&pcrs, Some(&[0u8; 16]));
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, Some(&[0u8; 16]));
         assert!(result.is_err(), "non-32-byte hash should be rejected");
     }
 
     #[test]
     fn test_check_init_data_too_few_pcrs() {
         let pcrs = vec![vec![0u8; 32]; 8]; // only PCR[0..7]
-        let result = check_init_data(&pcrs, Some(&[0u8; 32]));
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, Some(&[0u8; 32]));
         assert!(result.is_err(), "should fail with too few PCRs");
+    }
+
+    /// Regression PoC: an unselected PCR[8] must never be trusted.
+    ///
+    /// An attacker on a genuine Azure CVM issues a real AK-signed TPM2_Quote
+    /// whose selection excludes PCR 8, then appends a forged
+    /// pcrs[8] = SHA-256(0^32 || attacker_init_data). verify_tpm_pcrs passes
+    /// (it only hashes the selected PCRs), so before this fix check_init_data
+    /// reported InitDataMatch=true for init-data the TEE never measured.
+    #[test]
+    fn test_check_init_data_rejects_unselected_pcr8() {
+        let attacker_init_data = [0x42; 32];
+        let forged = crate::utils::sha256_two(&[0u8; 32], &attacker_init_data);
+
+        let mut pcrs = vec![vec![0u8; 32]; 24];
+        pcrs[8] = forged;
+
+        // The quote is genuine and internally consistent: its selection covers
+        // PCRs 0-7, whose values are untouched, so the PCR digest check passes.
+        let mut pcr_concat = Vec::new();
+        for pcr in pcrs.iter().take(8) {
+            pcr_concat.extend_from_slice(pcr);
+        }
+        let digest = crate::utils::sha256(&pcr_concat);
+        let msg = build_tpms_attest(&[0u8; 32], &[3, 0xFF, 0x00, 0x00], &digest);
+
+        assert!(
+            verify_tpm_pcrs(&msg, &pcrs).is_ok(),
+            "precondition: the quote's own PCR digest must verify, so that the \
+             only thing standing between the forged PCR[8] and a true result is \
+             the selection-membership check"
+        );
+
+        let result = check_init_data(&msg, &pcrs, Some(&attacker_init_data));
+        assert!(
+            result.is_err(),
+            "PCR[8] outside the signed selection is unauthenticated and must be \
+             rejected, not reported as InitDataMatch=true"
+        );
+    }
+
+    /// The same forged value is accepted once PCR 8 is genuinely in the signed
+    /// selection — confirming the test above fails for the right reason.
+    #[test]
+    fn test_check_init_data_accepts_selected_pcr8() {
+        let init_data = [0x42; 32];
+        let extended = crate::utils::sha256_two(&[0u8; 32], &init_data);
+
+        let mut pcrs = vec![vec![0u8; 32]; 24];
+        pcrs[8] = extended;
+
+        let result = check_init_data(&attest_selecting_pcr8(), &pcrs, Some(&init_data));
+        assert_eq!(result.unwrap(), Some(true));
     }
 }

--- a/crates/attestation/src/platforms/tpm_common.rs
+++ b/crates/attestation/src/platforms/tpm_common.rs
@@ -9,10 +9,13 @@ use std::sync::Once;
 
 use crate::error::{AttestationError, Result};
 use crate::types::{Claims, PlatformType, VerificationResult};
-use crate::utils::strip_trailing_nulls;
+use crate::utils::{constant_time_eq, sha256, sha256_two, strip_trailing_nulls};
 
 /// Decoded TPM quote components: (signature, message, pcr_values).
 pub type DecodedTpmQuote = (Vec<u8>, Vec<u8>, Vec<Vec<u8>>);
+
+/// The PCR index that init-data is measured into (PCR[8] = SHA256(0^32 || init_data_hash)).
+const INIT_DATA_PCR: usize = 8;
 
 /// The vTPM device path `az_cvm_vtpm` opens (`TctiNameConf::Device` default).
 #[cfg(all(feature = "attest", target_os = "linux"))]
@@ -125,11 +128,11 @@ pub const HCL_REPORT_TYPE_TDX: u32 = 4;
 ///
 /// Shared between Azure SNP and Azure TDX verification paths.
 pub fn verify_hcl_var_data_binding(report_data: &[u8], var_data: &[u8]) -> Result<()> {
-    let hash = crate::utils::sha256(var_data);
+    let hash = sha256(var_data);
     let report_data_prefix = report_data.get(..32).ok_or_else(|| {
         AttestationError::QuoteParseFailed("report_data shorter than 32 bytes".to_string())
     })?;
-    if !crate::utils::constant_time_eq(report_data_prefix, &hash) {
+    if !constant_time_eq(report_data_prefix, &hash) {
         return Err(AttestationError::SignatureVerificationFailed(
             "HCL var_data binding failed: report_data[..32] != SHA-256(var_data)".to_string(),
         ));
@@ -471,7 +474,7 @@ pub fn verify_tpm_nonce(message: &[u8], expected: &[u8]) -> Result<()> {
             "TPM nonce length mismatch".to_string(),
         ));
     }
-    if !crate::utils::constant_time_eq(&nonce, expected) {
+    if !constant_time_eq(&nonce, expected) {
         return Err(AttestationError::ReportDataMismatch);
     }
     Ok(())
@@ -526,9 +529,9 @@ pub fn verify_tpm_pcrs(message: &[u8], pcrs: &[Vec<u8>]) -> Result<()> {
         pcr_concat.extend_from_slice(&pcrs[idx]);
     }
 
-    let computed_digest = crate::utils::sha256(&pcr_concat);
+    let computed_digest = sha256(&pcr_concat);
 
-    if !crate::utils::constant_time_eq(&computed_digest, &expected_digest) {
+    if !constant_time_eq(&computed_digest, &expected_digest) {
         return Err(AttestationError::QuoteParseFailed(
             "PCR digest in TPM quote does not match hash of PCR values".to_string(),
         ));
@@ -672,22 +675,21 @@ pub fn check_init_data(
         )));
     }
     let (selected_pcrs, _) = parse_quote_info(tpm_msg)?;
-    if !selected_pcrs.contains(&8) {
-        return Err(AttestationError::QuoteParseFailed(
-            "init_data check requires PCR[8], but it is not in the quote's signed PCR selection \
-             (the supplied value would be unauthenticated)"
-                .to_string(),
-        ));
-    }
-    if tpm_pcrs.len() <= 8 {
+    if !selected_pcrs.contains(&INIT_DATA_PCR) {
         return Err(AttestationError::QuoteParseFailed(format!(
-            "init_data check requires PCR[8], but only {} PCR values were supplied",
+            "init_data check requires PCR[{INIT_DATA_PCR}], but it is not in the quote's signed \
+             PCR selection (the supplied value would be unauthenticated)"
+        )));
+    }
+    if tpm_pcrs.len() <= INIT_DATA_PCR {
+        return Err(AttestationError::QuoteParseFailed(format!(
+            "init_data check requires PCR[{INIT_DATA_PCR}], but only {} PCR values were supplied",
             tpm_pcrs.len()
         )));
     }
     // Compute TPM PCR extend: PCR[8] = SHA256(zeros_32 || init_data_hash)
-    let extended = crate::utils::sha256_two(&[0u8; 32], expected);
-    if !crate::utils::constant_time_eq(&tpm_pcrs[8], &extended) {
+    let extended = sha256_two(&[0u8; 32], expected);
+    if !constant_time_eq(&tpm_pcrs[INIT_DATA_PCR], &extended) {
         return Err(AttestationError::InitDataMismatch);
     }
     Ok(Some(true))


### PR DESCRIPTION
## Summary

`check_init_data` read `tpm_pcrs[8]` unconditionally, but `tpm_pcrs` is attacker-controlled data carried alongside the quote. This let an attacker on a genuine Azure CVM spoof `init_data_match = true` for init-data the TEE never measured.

## The gap

A `TPM2_Quote` does not sign PCR values. It signs a `TPMS_ATTEST` whose attested body contains a `pcrSelect` bitmap and a `pcrDigest` over *only* the PCRs named in that selection. The actual PCR contents travel separately, in `TpmQuote.pcrs` from the evidence JSON.

So `verify_tpm_pcrs` establishes a conditional guarantee:

> `tpm_pcrs[i]` is authentic **if and only if** `i` is in `selected_pcrs`.

```rust
let (selected_pcrs, expected_digest) = parse_quote_info(message)?;
for &idx in &selected_pcrs {          // only the selected indices
    pcr_concat.extend_from_slice(&pcrs[idx]);
}
```

Entries outside the selection contribute nothing to the digest — they are free-form attacker bytes that passed through a function with "verify" in its name. And the selection is an input parameter to `TPM2_Quote`, so the attacker picks it.

`check_init_data` received only `tpm_pcrs`, so it could not know what the selection was, and indexed 8 blindly.

## The attack

On Azure CVMs the convention is that init-data (workload/config identity) is measured into PCR 8 from a zero state, so `PCR[8] = SHA-256(0^32 ‖ init_data_hash)`.

1. On a genuine Azure CVM, call `TPM2_Quote` with a selection covering PCRs 0-7 and omitting PCR 8. Entirely legitimate; the real AK signs it.
2. Assemble evidence with the real HCL report, real VCEK/TD quote, real quote signature and message. Set `pcrs[0..7]` to their true values and forge `pcrs[8] = SHA-256(0^32 ‖ attacker_init_data)`.
3. Verification: hardware report valid, AK binding valid, quote signature valid, `verify_tpm_pcrs` passes (PCRs 0-7 hash correctly and `pcrs[8]` is never touched), and `check_init_data` then compares the forged `pcrs[8]` and returns `Some(true)`.

Every cryptographic check passes legitimately. There is no forged signature anywhere — the gap is entirely between what the signature covers and what the code reads.

Worth noting the marginal risk explicitly: this is **not** equivalent to an attacker honestly extending PCR 8. Because PCR extend is one-way, that alternative only works from a zero state. This bug makes the actual state of PCR[8] irrelevant, so it works even when PCR 8 was already correctly extended with the real init-data at boot — no reboot, no race against firmware measurement.

## Impact

Init-data is how a relying party pins workload and config identity on az-snp/az-tdx. Spoofing it means an attacker on any genuine CVM can claim to be running any workload while the evidence looks impeccable end to end.

Scope: only affects consumers that pin `expected_init_data_hash`. Reachable from the native az-snp/az-tdx paths and from the WASM entrypoints (`verify_az_snp`, `verify_az_tdx`), which forward `expected_init_data_hash` into `VerifyParams` — so a browser-side policy layer reads a spoofable `init_data_match`.

## The fix

Re-derive the signed selection from the already-signature-verified quote message and require index 8 to be present before reading `tpm_pcrs[8]`:

```rust
let (selected_pcrs, _) = parse_quote_info(tpm_msg)?;
if !selected_pcrs.contains(&8) {
    return Err(AttestationError::QuoteParseFailed(
        "init_data check requires PCR[8], but it is not in the quote's signed PCR selection \
         (the supplied value would be unauthenticated)".to_string(),
    ));
}
```

`check_init_data` now takes the quote message; both call sites (`az_snp/verify.rs`, `az_tdx/verify.rs`) already had `tpm_msg` in scope. The too-few-PCRs case now returns a descriptive parse error rather than `InitDataMismatch`, which conflated malformed input with a genuine mismatch.

## Testing

- New regression PoC `test_check_init_data_rejects_unselected_pcr8`: builds a genuine, internally consistent quote whose selection excludes PCR 8, asserts `verify_tpm_pcrs` passes (so the membership check is the only thing standing between the forged value and a `true` result), then asserts `check_init_data` rejects it. **Verified to fail without the fix.**
- `test_check_init_data_accepts_selected_pcr8` confirms the same value is accepted once PCR 8 is genuinely in the selection, so the PoC cannot pass for the wrong reason.
- Existing `check_init_data` tests updated for the new signature.
- `cargo test -p attestation --lib`: 174 passed. `cargo build --workspace`, `cargo fmt --check`, `cargo clippy --all-targets`: clean.

## Follow-up (not in this PR)

`build_tpm_verification_result` publishes *all* PCR entries into `platform_data["tpm"]["pcrNN"]` with no indication of which were signed. Nothing in-tree makes decisions on those, but a downstream consumer pinning e.g. `platform_data.tpm.pcr11` inherits the same fail-open. Emitting only selected PCRs, or adding a `signed_pcrs` list, would close it — the selection list is already computed.

The general rule this reflects: every PCR consumed for a decision must be inside the quote's signed selection.
