### PR TITLE
feat(wasm): generic platform-dispatching verify export + Verifier offline mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "x509-cert",
  "x509-parser",
@@ -2764,6 +2765,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",

--- a/crates/attestation-wasm/src/lib.rs
+++ b/crates/attestation-wasm/src/lib.rs
@@ -14,6 +14,60 @@ use attestation::platforms::tdx::verify::verify_evidence as verify_tdx_evidence;
 use attestation::types::{ProcessorGeneration, VerifyParams};
 use attestation::utils::{constant_time_eq, pad_report_data};
 
+/// Verify attestation evidence from a self-describing envelope — the generic,
+/// platform-dispatching entry point and the preferred API for JS embedders.
+///
+/// `envelope_json` is the core [`attestation::AttestationEvidence`] envelope:
+/// `{ "platform": "<tag>", "evidence": { ... } }`, where `platform` is one of
+/// the compiled-in platform tags (`snp`, `tdx`, `az-snp`, `az-tdx`, `gcp-snp`,
+/// `gcp-tdx` with default features) and `evidence` is that platform's evidence
+/// payload, verbatim. Dispatch happens in the Rust core
+/// (`Verifier::verify_platform`), so JS callers need no per-platform routing —
+/// but they MUST assert the platform themselves by comparing the result's
+/// `platform` field against the one they expect, never trusting a
+/// server-chosen tag to pick the verification path.
+///
+/// Runs in offline mode ([`attestation::Verifier::offline`]): quote signatures
+/// and cert chains verify against the bundled AMD/Intel roots (SNP evidence
+/// must carry its VEK inline, as c8s evidence does), the SNP processor
+/// generation is auto-detected from the report's CPUID fields (v3+ reports),
+/// and the network-backed collateral checks (PCK CRL, TCB status, QE identity)
+/// are skipped — `collateral_verified` stays `false`. Debug guests are always
+/// rejected (`allow_debug` is never exposed to the browser; fail closed).
+///
+/// The freshness semantics of `expected_report_data` are per-platform, handled
+/// inside each core verifier: for bare-metal platforms it is checked against
+/// the hardware quote's `report_data` (zero-padded, constant-time); for the
+/// Azure vTPM platforms it is checked against the vTPM quote's `extraData`.
+/// Either way a supplied-but-mismatched anchor fails closed.
+///
+/// - `envelope_json`: `{ platform, evidence }` envelope JSON
+/// - `expected_report_data`: optional freshness anchor bytes
+/// - `expected_init_data_hash`: optional init-data binding (SNP HOST_DATA /
+///   TDX MRCONFIGID / vTPM PCR[8])
+///
+/// Returns the [`attestation::types::VerificationResult`] as JSON, or throws
+/// on any check failure.
+#[wasm_bindgen]
+pub async fn verify(
+    envelope_json: String,
+    expected_report_data: Option<Vec<u8>>,
+    expected_init_data_hash: Option<Vec<u8>>,
+) -> Result<String, JsError> {
+    let params = VerifyParams {
+        expected_report_data,
+        expected_init_data_hash,
+        ..VerifyParams::default()
+    };
+
+    let result = attestation::Verifier::offline()
+        .verify(envelope_json.as_bytes(), &params)
+        .await
+        .map_err(|e| JsError::new(&format!("verify: {e}")))?;
+
+    serde_json::to_string_pretty(&result).map_err(|e| JsError::new(&format!("json serialize: {e}")))
+}
+
 /// Verify live SNP evidence in WASM.
 ///
 /// - `evidence_json`: evidence JSON with inline cert_chain.vcek

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -270,7 +270,10 @@ pub const MAX_EVIDENCE_SIZE: usize = 10 * 1024 * 1024;
 /// ```
 pub struct Verifier {
     cert_provider: Box<dyn CertProvider>,
-    tdx_provider: Box<dyn TdxCollateralProvider>,
+    /// `None` = offline: TDX collateral checks (PCK CRL, TCB status, QE
+    /// identity) are skipped and `collateral_verified` stays `false`. See
+    /// [`Verifier::offline`].
+    tdx_provider: Option<Box<dyn TdxCollateralProvider>>,
     #[cfg(feature = "nvidia-gpu")]
     nras_provider: Box<dyn platforms::nvidia_gpu::NrasProvider>,
 }
@@ -280,7 +283,7 @@ impl Verifier {
     pub fn new() -> Self {
         Self {
             cert_provider: Box::new(DefaultCertProvider::new()),
-            tdx_provider: Box::new(DefaultTdxCollateralProvider::new()),
+            tdx_provider: Some(Box::new(DefaultTdxCollateralProvider::new())),
             #[cfg(feature = "nvidia-gpu")]
             nras_provider: Box::new(platforms::nvidia_gpu::DefaultNrasProvider::new()),
         }
@@ -294,8 +297,24 @@ impl Verifier {
 
     #[must_use]
     pub fn with_tdx_provider(mut self, provider: impl TdxCollateralProvider + 'static) -> Self {
-        self.tdx_provider = Box::new(provider);
+        self.tdx_provider = Some(Box::new(provider));
         self
+    }
+
+    /// A verifier with no network-backed collateral: quote signatures and cert
+    /// chains verify against the bundled AMD/Intel roots (SNP needs an inline
+    /// VEK in the evidence), while the TDX collateral checks (PCK CRL, TCB
+    /// status, QE identity) are skipped and `collateral_verified` stays
+    /// `false`. This is the mode the WASM verifier runs in, where the default
+    /// providers cannot reach AMD KDS / Intel PCS.
+    #[must_use]
+    pub fn offline() -> Self {
+        Self {
+            cert_provider: Box::new(DefaultCertProvider::new()),
+            tdx_provider: None,
+            #[cfg(feature = "nvidia-gpu")]
+            nras_provider: Box::new(platforms::nvidia_gpu::DefaultNrasProvider::new()),
+        }
     }
 
     #[cfg(feature = "nvidia-gpu")]
@@ -362,6 +381,13 @@ impl Verifier {
         Ok(result)
     }
 
+    /// The TDX collateral provider to pass to platform verifiers (`None` in
+    /// offline mode).
+    #[allow(dead_code)]
+    fn tdx_collateral(&self) -> Option<&dyn TdxCollateralProvider> {
+        self.tdx_provider.as_deref()
+    }
+
     #[allow(unused_variables)]
     async fn verify_platform(
         &self,
@@ -381,12 +407,7 @@ impl Verifier {
             PlatformType::Tdx => {
                 let ev: platforms::tdx::evidence::TdxEvidence = serde_json::from_value(evidence)
                     .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?;
-                platforms::tdx::verify::verify_evidence(
-                    &ev,
-                    params,
-                    Some(self.tdx_provider.as_ref()),
-                )
-                .await
+                platforms::tdx::verify::verify_evidence(&ev, params, self.tdx_collateral()).await
             }
             #[cfg(feature = "az-snp")]
             PlatformType::AzSnp => {
@@ -401,12 +422,7 @@ impl Verifier {
                 let ev: platforms::az_tdx::evidence::AzTdxEvidence =
                     serde_json::from_value(evidence)
                         .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?;
-                platforms::az_tdx::verify::verify_evidence(
-                    &ev,
-                    params,
-                    Some(self.tdx_provider.as_ref()),
-                )
-                .await
+                platforms::az_tdx::verify::verify_evidence(&ev, params, self.tdx_collateral()).await
             }
             #[cfg(feature = "gcp-snp")]
             PlatformType::GcpSnp => {
@@ -423,24 +439,14 @@ impl Verifier {
             PlatformType::GcpTdx => {
                 let ev: platforms::tdx::evidence::TdxEvidence = serde_json::from_value(evidence)
                     .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?;
-                platforms::gcp_tdx::verify::verify_evidence(
-                    &ev,
-                    params,
-                    Some(self.tdx_provider.as_ref()),
-                )
-                .await
+                platforms::gcp_tdx::verify::verify_evidence(&ev, params, self.tdx_collateral()).await
             }
             #[cfg(feature = "dstack")]
             PlatformType::Dstack => {
                 let ev: platforms::dstack::evidence::DstackEvidence =
                     serde_json::from_value(evidence)
                         .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?;
-                platforms::dstack::verify::verify_evidence(
-                    &ev,
-                    params,
-                    Some(self.tdx_provider.as_ref()),
-                )
-                .await
+                platforms::dstack::verify::verify_evidence(&ev, params, self.tdx_collateral()).await
             }
             #[cfg(not(all(
                 feature = "snp",

--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -439,7 +439,8 @@ impl Verifier {
             PlatformType::GcpTdx => {
                 let ev: platforms::tdx::evidence::TdxEvidence = serde_json::from_value(evidence)
                     .map_err(|e| AttestationError::EvidenceDeserialize(e.to_string()))?;
-                platforms::gcp_tdx::verify::verify_evidence(&ev, params, self.tdx_collateral()).await
+                platforms::gcp_tdx::verify::verify_evidence(&ev, params, self.tdx_collateral())
+                    .await
             }
             #[cfg(feature = "dstack")]
             PlatformType::Dstack => {


### PR DESCRIPTION
## Problem

The WASM crate exposes one hand-written entry point per platform (`verify_snp`, `verify_az_snp`, `verify_az_tdx`, and `verify_tdx` from #71), so WASM coverage permanently lags the core: the `gcp-snp`/`gcp-tdx` verifiers are compiled **into** the shipped binary (default features) but unreachable, and every new platform needs a new export plus matching per-platform routing in JS embedders like c8s-verify-js.

Meanwhile the core already has the right API — `Verifier::verify()` consumes a self-describing `{platform, evidence}` envelope and dispatches internally. It was unusable from WASM for one reason: it always passes `Some(tdx_provider)`, and the default providers error on any fetch under wasm32, so every TDX verification would fail closed for lack of Intel PCS collateral.

## Change

**attestation** — `Verifier`'s TDX collateral provider becomes `Option`al, plus a `Verifier::offline()` constructor: signatures and cert chains verify against the bundled AMD/Intel roots (SNP needs its VEK inline, which c8s evidence carries), collateral checks (PCK CRL, TCB status, QE identity) are skipped, `collateral_verified` stays `false`. This is exactly the trade-off the per-platform WASM exports already made by passing `None` — the generic path just had no way to express it. Native behavior is unchanged (`new()` still installs the default Intel PCS provider).

**attestation-wasm** — new generic export:

```ts
verify(envelope_json: string, expected_report_data?: Uint8Array, expected_init_data_hash?: Uint8Array): Promise<string>
```

Covers every compiled-in platform — `snp`, `tdx`, `az-snp`, `az-tdx`, `gcp-snp`, `gcp-tdx` with default features (`dstack`/`nvidia-gpu` stay behind non-default features). SNP processor generation is auto-detected from v3+ report CPUID fields (no generation argument). Debug guests are always rejected — `allow_debug` is not exposed to the browser. Per-platform freshness semantics (quote `report_data` vs vTPM `extraData`) are handled where they belong, inside each core verifier.

The four per-platform exports remain for compatibility and should be treated as legacy; the companion c8s-verify-js change collapses its per-platform routing onto `verify()`. JS callers must still assert their expected platform against the result's `platform` field — never let a server-chosen tag pick the verification path.

## Testing

- `cargo test -p attestation` — 172 passed.
- `cargo check`/`clippy -p attestation-wasm --target wasm32-unknown-unknown` — clean.
- Companion c8s-verify-js branch rebuilds the WASM from this branch and runs its full suite through `verify()`, including a live-captured bare-metal TDX bundle and a live cluster connect.
