### PR TITLE
ci: enable the azure-tdx cell (standalone DC4es_v6 runner, westus)

### DIFF
--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -48,15 +48,21 @@ jobs:
           #   filter: "binary(capture_fixture)"       # the native TDX test binary
           #   test_threads: "2"
           #   tee_dev: /dev/tdx-guest
-          # azure-tdx: Azure vTPM TDX (az_tdx_live). DEFERRED — Azure TDX conf VMs are
-          #   preview-only (EastUS2EUAP canary; no GA/AKS support), so no azure-cvm
-          #   variant yet.
-          # - platform: azure-tdx
-          #   runs_on: azure-tdx-cvm
-          #   features: "attest,az-tdx"
-          #   filter: "binary(az_tdx_live)"
-          #   test_threads: "1"
-          #   tee_dev: /dev/tpmrm0
+          # azure-tdx: Azure vTPM TDX (az_tdx_live, runnable nowhere else). Runner =
+          #   a standalone DC4es_v6 TDX CVM in westeurope (confidential-ci
+          #   provision-azure-tdx-cvm.yml): GA'd v6 sizes, but AKS still refuses TDX
+          #   node pools (Azure/AKS#5618), hence not an azure-cvm AKS twin. Attests
+          #   via vTPM + IMDS /acc/tdquote, so the device gate is /dev/tpmrm0, same
+          #   as the SNP azure cell; nextest already serialises both az binaries in
+          #   the max-1 vtpm group. Expect 14 EXECUTED tests here: az_tdx_live
+          #   skips itself silently when IMDS says the VM is not TDX, and a
+          #   skipped-green run tests nothing.
+          - platform: azure-tdx
+            runs_on: azure-tdx-cvm
+            features: "attest,az-tdx"
+            filter: "binary(az_tdx_live)"
+            test_threads: "1"
+            tee_dev: /dev/tpmrm0
     name: tee (${{ matrix.platform }})
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 45

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -4,7 +4,7 @@ name: confidential-e2e
 # archive, no serial console, no ci-tests OCI package). ONE matrix, per-platform
 # cells because attestation-rs tests each attestation MECHANISM separately:
 #   snp-metal-cvm : native SEV-SNP via /dev/sev-guest  (--features attest)
-#   azure-cvm     : Azure SEV-SNP via the vTPM/HCL      (--features attest,az-snp,
+#   azure-snp-cvm : Azure SEV-SNP via the vTPM/HCL      (--features attest,az-snp,
 #                   az_snp_live only — runnable nowhere else)
 # Adding a platform later (tdx-metal-cvm, azure-tdx-cvm) = one more include line.
 # Trigger: push:main + dispatch. NEVER pull_request (org self-hosted hardware).
@@ -33,7 +33,7 @@ jobs:
             test_threads: "2"
             tee_dev: /dev/sev-guest
           - platform: azure
-            runs_on: azure-cvm
+            runs_on: azure-snp-cvm
             features: "attest,az-snp"
             filter: "binary(az_snp_live)"             # the Azure vTPM tests, runnable nowhere else
             test_threads: "1"                         # the emulated vTPM serialises — 1 proc avoids session contention

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -49,7 +49,7 @@ jobs:
           #   test_threads: "2"
           #   tee_dev: /dev/tdx-guest
           # azure-tdx: Azure vTPM TDX (az_tdx_live, runnable nowhere else). Runner =
-          #   a standalone DC4es_v6 TDX CVM in westeurope (confidential-ci
+          #   a standalone DC4es_v6 TDX CVM in westus (confidential-ci
           #   provision-azure-tdx-cvm.yml): GA'd v6 sizes, but AKS still refuses TDX
           #   node pools (Azure/AKS#5618), hence not an azure-cvm AKS twin. Attests
           #   via vTPM + IMDS /acc/tdquote, so the device gate is /dev/tpmrm0, same

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -32,7 +32,7 @@ jobs:
             filter: "not (binary(az_snp_live) | binary(az_tdx_live) | binary(capture_fixture))"  # az_* are the azure cell; capture_fixture is TDX
             test_threads: "2"
             tee_dev: /dev/sev-guest
-          - platform: azure
+          - platform: azure-snp
             runs_on: azure-snp-cvm
             features: "attest,az-snp"
             filter: "binary(az_snp_live)"             # the Azure vTPM tests, runnable nowhere else

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -63,7 +63,7 @@ jobs:
             filter: "binary(az_tdx_live)"
             test_threads: "1"
             tee_dev: /dev/tpmrm0
-    name: tee (${{ matrix.platform }})
+    name: tee (${{ matrix.runs_on }})   # job name == runner label, matching kettle — grep-able straight to the runner
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## What

Uncomments the staged `azure-tdx` matrix cell and replaces its stale deferral comment ("preview-only, EastUS2EUAP, no GA") with the current facts.

## Why now

TDX v6 CVMs are GA in westeurope (capability-verified, quota in hand). AKS still refuses TDX node pools ([Azure/AKS#5618](https://github.com/Azure/AKS/issues/5618)), so the runner is a standalone DC4es_v6 CVM with ARC in-guest: confidential-ci `provision-azure-tdx-cvm.yml`, merged and dispatched today. The cell's own values are unchanged from what PR #70 staged.

## First-run check

Expect **14 executed** `az_tdx_live` tests. The binary self-skips silently on non-TDX VMs, so a green run consisting of skips tests nothing. This is the first run of the az-tdx path on real TDX silicon.

Merge after the `azure-tdx-cvm` listener is confirmed live (merge to main triggers the run).