### PR TITLE
feat(api): gate GPU evidence collection behind config

### DIFF
--- a/crates/attestation-api/README.md
+++ b/crates/attestation-api/README.md
@@ -74,6 +74,7 @@ key_path = ""                   # Empty = ephemeral key
 [attestation]
 enabled = true                  # Set to false to disable /attest
 platforms = ["snp", "tdx", "az-snp", "az-tdx", "gcp-snp", "gcp-tdx"]
+gpu_attestation_evidence_enabled = false # Evidence collection only; disabled by default
 ```
 
 ## Authentication
@@ -83,6 +84,19 @@ When `auth.api_keys` contains one or more Bearer tokens, all endpoints except `/
 ## Attestation
 
 The `/attest` endpoint is available when `attestation.enabled = true` (the default). Set it to `false` on verification-only deployments. The `attestation.platforms` list controls which platforms the service is allowed to generate evidence for.
+
+### NVIDIA GPU evidence status
+
+`/attest` always returns a machine-readable `gpu_attested` field. Its default
+value is `"unknown"`: the service did not collect or verify GPU evidence. Set
+`attestation.gpu_attestation_evidence_enabled = true` and request
+`"nvidia_gpu": true` to collect raw GPU evidence. The response then says
+`"evidence_collected"`, which is **not** an attestation pass. A caller must
+send that evidence to `/verify` with GPU verification required and accept only
+a successful NVIDIA verification result before it reports a GPU as attested.
+
+This configuration switch does not issue credentials, change c8s policy, or
+release an encrypted volume. It only controls evidence collection at `/attest`.
 
 ## Usage Examples
 

--- a/crates/attestation-api/config.example.toml
+++ b/crates/attestation-api/config.example.toml
@@ -29,3 +29,7 @@ key_path = ""                     # Empty = ephemeral EC key
 [attestation]
 enabled = true                    # Set to false to disable the /attest endpoint
 platforms = ["snp", "tdx", "az-snp", "az-tdx", "gcp-snp", "gcp-tdx"]
+# Disabled by default. When false, /attest always returns
+# `"gpu_attested":"unknown"` and never collects GPU evidence. When true,
+# the caller must also send `"nvidia_gpu":true`; collection is not verification.
+gpu_attestation_evidence_enabled = false

--- a/crates/attestation-api/src/api/attest.rs
+++ b/crates/attestation-api/src/api/attest.rs
@@ -12,6 +12,18 @@ use crate::config::normalize_platform;
 use crate::error::ApiError;
 use crate::AppState;
 
+/// The `/attest` endpoint only creates evidence. It never verifies NVIDIA GPU
+/// evidence, so it never reports a positive GPU-attestation result.
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuAttestedStatus {
+    /// GPU evidence collection is disabled, or the caller did not request it.
+    Unknown,
+    /// Raw GPU evidence was collected. The caller must submit it to `/verify`
+    /// and require NVIDIA GPU verification before treating it as attested.
+    EvidenceCollected,
+}
+
 #[derive(Deserialize)]
 pub struct AttestRequest {
     pub report_data: Option<String>,
@@ -31,6 +43,8 @@ fn default_platform() -> String {
 pub struct AttestResponse {
     pub platform: String,
     pub evidence: Value,
+    /// `unknown` by default. `evidence_collected` is not a verification pass.
+    pub gpu_attested: GpuAttestedStatus,
     /// Present when the request set `nvidia_gpu: true` and GPU evidence
     /// collection succeeded. Round-trips through `/verify` unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,7 +72,9 @@ pub async fn handler(
         ensure_platform_allowed(&state.config.attestation.platforms, platform)?;
         let options = state.config.attestation.attest_options();
 
-        let evidence_bytes = if req.nvidia_gpu {
+        let collect_gpu_evidence =
+            req.nvidia_gpu && state.config.attestation.gpu_attestation_evidence_enabled;
+        let evidence_bytes = if collect_gpu_evidence {
             #[cfg(feature = "nvidia-gpu-attest")]
             {
                 attestation::attest_with_nvidia_gpu(platform, &report_data, &options).await?
@@ -88,6 +104,11 @@ pub async fn handler(
         Ok(Json(AttestResponse {
             platform: format!("{platform}"),
             evidence: envelope.get("evidence").cloned().unwrap_or(envelope),
+            gpu_attested: if collect_gpu_evidence {
+                GpuAttestedStatus::EvidenceCollected
+            } else {
+                GpuAttestedStatus::Unknown
+            },
             nvidia_gpu: gpu_field,
         }))
     }
@@ -130,5 +151,39 @@ fn ensure_platform_allowed(
         Err(ApiError::BadRequest(format!(
             "platform '{platform_name}' is not allowed by attestation.platforms"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AttestResponse, GpuAttestedStatus};
+    use serde_json::json;
+
+    #[test]
+    fn disabled_gpu_attestation_serializes_as_unknown() {
+        let response = AttestResponse {
+            platform: "tdx".to_string(),
+            evidence: json!({}),
+            gpu_attested: GpuAttestedStatus::Unknown,
+            nvidia_gpu: None,
+        };
+
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["gpu_attested"], "unknown");
+        assert!(json.get("nvidia_gpu").is_none());
+    }
+
+    #[test]
+    fn evidence_collection_is_not_serialized_as_a_pass() {
+        let response = AttestResponse {
+            platform: "tdx".to_string(),
+            evidence: json!({}),
+            gpu_attested: GpuAttestedStatus::EvidenceCollected,
+            nvidia_gpu: Some(json!({"bundle": "raw"})),
+        };
+
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["gpu_attested"], "evidence_collected");
+        assert_ne!(json["gpu_attested"], "true");
     }
 }

--- a/crates/attestation-api/src/config.rs
+++ b/crates/attestation-api/src/config.rs
@@ -142,6 +142,11 @@ pub struct AttestationConfig {
     /// - "vsock": direct AF_VSOCK to QGS only. Requires vhost-vsock-pci + QGS.
     /// - "configfs": kernel ConfigFS TSM only. Use on GCP and other cloud platforms.
     pub tdx_quote_method: String,
+    /// If true, `/attest` may collect raw NVIDIA GPU evidence when the caller
+    /// also sets `nvidia_gpu: true`. This is disabled by default. Enabling
+    /// collection does not verify the evidence and does not change credential
+    /// issuance or any c8s authorization decision.
+    pub gpu_attestation_evidence_enabled: bool,
 }
 
 // --- Defaults ---
@@ -198,6 +203,7 @@ impl Default for AttestationConfig {
             ],
             allow_debug: false,
             tdx_quote_method: "auto".to_string(),
+            gpu_attestation_evidence_enabled: false,
         }
     }
 }
@@ -357,6 +363,15 @@ mod tests {
         assert!(
             config.validate().is_err(),
             "tdx_collateral_ttl_hours = 0 should be rejected"
+        );
+    }
+
+    #[test]
+    fn gpu_evidence_collection_is_disabled_by_default() {
+        assert!(
+            !Config::default()
+                .attestation
+                .gpu_attestation_evidence_enabled
         );
     }
 }


### PR DESCRIPTION
Adds a disabled-by-default GPU evidence collection control. `/attest` returns `gpu_attested: "unknown"` and does not collect NVIDIA evidence while disabled, including when the request has `nvidia_gpu: true`. When explicitly enabled, the response is `evidence_collected`, not an attestation pass. CPU c8s flows and credential/volume policy are unchanged.