### PR TITLE
ci: build the service image once; cache deps via cargo-chef; cache cargo-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,28 +159,22 @@ jobs:
             dist/attestation-cli
           if-no-files-found: error
 
+  # One build for both purposes: PRs validate it, main pushes it. The image
+  # was previously built twice (a push:false job, then a from-scratch rebuild
+  # in a publish job); layer cache in the gha backend plus cargo-chef in the
+  # Dockerfile keeps warm builds to the changed crates.
   docker-build:
     name: Docker Build
     needs: [check, test]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          push: false
-
-  publish-service-image:
-    name: Publish Service Image
-    needs: [docker-build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -196,9 +190,11 @@ jobs:
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Cuts a GitHub Release named v{attestation-cli version} when that tag does
   # not already exist. Bump the version in crates/attestation-cli/Cargo.toml and
@@ -256,7 +252,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: cargo install cargo-audit
+      # ~2.5 min compile without the cache; the binary only changes when the
+      # pinned version below is bumped.
+      - name: Cache cargo-audit binary
+        id: audit-bin
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-0.22.2-${{ runner.os }}
+      - if: steps.audit-bin.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --locked --version 0.22.2
       # FIXME: Remove these ignores once upstream attestation-rs/sev updates deps.
       # RUSTSEC-2023-0071: rsa (Marvin attack, no patched version available)
       # RUSTSEC-2025-0141: bincode (unmaintained, used by sev crate)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-FROM rust:1.94-bookworm AS builder
-
-RUN apt-get update && apt-get install -y libtss2-dev && rm -rf /var/lib/apt/lists/*
-
+FROM rust:1.94-bookworm AS chef
+# Compiled once; the layer is reused until the base image or the pin changes.
+RUN cargo install cargo-chef --locked --version 0.1.78
 WORKDIR /app
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update && apt-get install -y libtss2-dev && rm -rf /var/lib/apt/lists/*
+# Dependency layer: keyed on the recipe (Cargo.toml/lock graph), so it is
+# reused across source-only changes instead of rebuilding every crate.
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
-
 RUN cargo build --release -p attestation-api --bin attestation-api
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Problem

Three independent time sinks. Every main push builds the service image twice: `docker-build` validates with `push: false`, then `publish-service-image` rebuilds the identical image from scratch on a different runner (2m46s + 2m54s, chained after check/test for a ~6m40s wall). Neither build uses a layer cache, and the Dockerfile copies all sources before `cargo build`, so any code change recompiles every dependency crate. Separately, the audit job runs `cargo install cargo-audit` from source on every run (~2.5 min of its 3m11s).

## Fix

- One `docker-build` job serves both purposes: PRs build without pushing, main pushes the same build (login/tags gated on the event). The publish job is gone.
- buildx with `type=gha` layer cache, and cargo-chef staging in the Dockerfile (chef pinned 0.1.78, compiled in the official rust image so no new base-image trust root): the dependency layer is keyed on the Cargo.toml/lock graph and survives source-only changes. Final stage and binary are unchanged.
- The audit job caches the cargo-audit binary keyed on a pinned version (0.22.2); install runs only on a cache miss.

Note: the merged docker job now carries `packages: write` on PR runs too (fork PRs still get a read-only token); the push step itself stays gated on main.

Expected: main-push wall ~6m40s to ~3m (one warm build instead of two cold ones), PR docker leg ~2m46s to under a minute on source-only changes, audit 3m11s to ~40s. First run per cache scope still pays the cold build.