### PR TITLE
fix(api): answer 502 for collateral this service could not fetch

### DIFF
--- a/crates/attestation-api/src/error.rs
+++ b/crates/attestation-api/src/error.rs
@@ -35,6 +35,11 @@ struct ErrorBody {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, error_key) = match &self {
+            // Collateral this service could not fetch, so it is the upstream that
+            // failed and not the submitted evidence.
+            ApiError::Verification(attestation::AttestationError::CertFetchError(_)) => {
+                (StatusCode::BAD_GATEWAY, "cert_fetch_failed")
+            }
             ApiError::Verification(_) => (StatusCode::UNPROCESSABLE_ENTITY, "verification_failed"),
             ApiError::NoPlatform => (StatusCode::SERVICE_UNAVAILABLE, "no_platform"),
             ApiError::AttestNotAvailable => (StatusCode::BAD_REQUEST, "attest_not_available"),
@@ -49,6 +54,11 @@ impl IntoResponse for ApiError {
                 tracing::error!(detail, "internal error");
                 "an internal error occurred".to_string()
             }
+            // The inner error alone: `Verification`'s "verification failed" prefix
+            // would name the evidence this status exists to stop naming.
+            ApiError::Verification(inner @ attestation::AttestationError::CertFetchError(_)) => {
+                inner.to_string()
+            }
             other => other.to_string(),
         };
 
@@ -58,5 +68,42 @@ impl IntoResponse for ApiError {
         };
 
         (status, axum::Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use attestation::AttestationError;
+
+    async fn error_key(resp: Response) -> String {
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read error body");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("error body is JSON");
+        json["error"].as_str().expect("error key").to_string()
+    }
+
+    #[tokio::test]
+    async fn collateral_this_service_could_not_fetch_is_an_upstream_failure() {
+        let resp = ApiError::Verification(AttestationError::CertFetchError(
+            "cached VCEK fetch: error sending request for url (https://kdsintf.amd.com/vcek/v1/Genoa/…)"
+                .to_string(),
+        ))
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(error_key(resp).await, "cert_fetch_failed");
+    }
+
+    #[tokio::test]
+    async fn a_chain_that_does_not_validate_is_still_a_verdict() {
+        let resp = ApiError::Verification(AttestationError::CertChainError(
+            "VCEK is not signed by the ASK".to_string(),
+        ))
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(error_key(resp).await, "verification_failed");
     }
 }


### PR DESCRIPTION
## What

`ApiError::Verification(AttestationError::CertFetchError(_))` renders as **502 `cert_fetch_failed`** instead of 422 `verification_failed`, and its body message drops the `verification failed:` prefix.

## Why

A VCEK fetch that fails because AMD KDS is unreachable arrives at `IntoResponse` as `Verification(CertFetchError)` and is rendered as a statement about the submitted evidence. It is a statement about this service's upstream, and callers act on the difference — a 4xx is a verdict every retry reproduces, so they stop retrying.

That is how a c8s kata guest ends up seed-only for the life of the pod. Its policy-monitor self-attests at `READY=1`, before kata-agent has installed the pod network, so the first VCEK fetch has no resolver:

```
API error (422): verification failed: certificate fetch failed:
cached VCEK fetch: error sending request for url
(https://kdsintf.amd.com/vcek/v1/Genoa/903074…)
```

The guest records that as a permanent verdict, never takes its CDS measurements, and `c8s allowlist workload apply` never reaches it. Reproduced on bare metal six consecutive rounds; KDS itself answered `200` in 0.147 s from the same host during the run.

## Why 502, not 503

`error.rs` already draws the line: **502 = an upstream dependency failed** (`ApiError::CertFetch`, same `cert_fetch_failed` key), **503 = this instance cannot serve at all** (`NoPlatform`). A KDS reach failure is the former, so this reuses the existing status and key rather than minting a second spelling for the same condition.

No client change is needed for this to take effect: c8s's `refusesEvidence` is 4xx-only, so 502 already classifies as retryable, and `initdata_test.go` already pins 5xx → `errAttestUnavailable`.

## Trade-off — please review this specifically

`CertFetchError` is not purely a transport class. A few conditions the *evidence* determines also land in it, and they move to 502 with everything else:

- a KDS 404/400 for a `chip_id` or `reported_tcb` that does not exist (`collateral.rs` `send_get` uses `error_for_status()`);
- SNP evidence with `MASK_CHIP_ID` set and no `cert_chain` (`platforms/snp/verify.rs`);
- a failed revocation check under `require_crl=true` (`certs/snp_provider.rs`).

Those now read as upstream failures and get retried by callers instead of refused promptly. Every such path stays fail-closed — nothing is admitted that was not admitted before — but two callers change posture: c8s CDS answers `502 attestation_api_unreachable` rather than `422 verification_failed`, and `c8s/internal/issuer/handoff_pull.go` classifies `>= 500` as `PullTransient` and retries rather than failing fast.

Splitting those properly means classifying at the fetch site rather than here, which this change cannot reach: `CertCache` returns `anyhow::Error`, so the variant is flattened to a string before `snp_provider` re-wraps it. Doing it right means a distinct error variant threaded through the cache layer — worth a follow-up, not worth blocking a p0 install defect on.

## Not in this PR

- The `#[cfg(feature = "nvidia-gpu")]` siblings `NrasRequestFailed` and `JwksFetch` are the same defect class, but are not on the guest boot path.
- `attestation-service/src/error.rs` is currently byte-identical to this file and will silently diverge.
- The rendered message contains the full KDS URL, including the 64-byte `chip_id` that `MASK_CHIP_ID` exists to hide. Pre-existing under 422; worth redacting separately.

## Test

Two unit tests on `IntoResponse` pin the split and the `error` key: `CertFetchError` → 502 `cert_fetch_failed`, and its near-neighbour `CertChainError` (a genuine verdict) → 422 `verification_failed`.

`cargo test -p attestation-api`, `cargo clippy --all-targets`, `cargo fmt --check` all clean locally.

Fixes the verifier half of the pod-as-CVM allowlist defect; the guest half is c8s#463.